### PR TITLE
Automatically deploy docs to GitHub pages using GitHub workflows

### DIFF
--- a/.github/workflows/deploy_docs_to_gh_pages.yaml
+++ b/.github/workflows/deploy_docs_to_gh_pages.yaml
@@ -16,19 +16,21 @@ on:
 
 jobs:
   deploy-docs-to-gh-pages:
+    # Do not run on forked repositories.
+    if: github.repository_owner == "HewlettPackard"
     runs-on: ubuntu-latest
     permissions:
       contents: write
     steps:
-      - name: Checkout
+      - name: Checkout Repository
         uses: actions/checkout@v3
 
-      - name: Setup Python
+      - name: Setup Python Environment
         uses: actions/setup-python@v3
         with:
           python-version: "3.8"
 
-      - name: Install Python dependencies
+      - name: Install Python Dependencies
         run: |
           python -m pip install --upgrade pip
           pip install -r docs/requirements.txt
@@ -41,7 +43,7 @@ jobs:
           mkdocs build --theme material --site-dir ../site/
           rm -r ../site/_src
 
-      - name: Deploy to GitHub Pages
+      - name: Deploy Docts To GitHub Pages
         # This step will deploy the generated documentation to `gh-pages` branch.
         uses: peaceiris/actions-gh-pages@v3.9.0
         with:

--- a/.github/workflows/deploy_docs_to_gh_pages.yaml
+++ b/.github/workflows/deploy_docs_to_gh_pages.yaml
@@ -9,11 +9,13 @@ on:
     branches:
       - main
     paths:
-      - "docs/**"
-      - ".github/workflows/deploy_docs.yml"
+      - ".github/workflows/deploy_docs_to_gh_pages.yaml"    # The workflow file itself.
+      - "docs/**"                                           # Documentation files
+      - "!docs/_src/**"                                     #   but exclude this one (raw resources for docs).
+      - "cmflib/cmf.py"                                     # Public API documentation.
 
 jobs:
-  deploy-docs:
+  deploy-docs-to-gh-pages:
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -33,6 +35,8 @@ jobs:
 
       - name: Build Docs
         working-directory: './'
+        # First - build documentation, then remove a directory that contains raw files for documentation assets, and
+        # these raw files are not required for running the CMF documentation site.
         run: |
           mkdocs build --theme material --site-dir ../site/
           rm -r ../site/_src

--- a/.github/workflows/deploy_docs_to_gh_pages.yaml
+++ b/.github/workflows/deploy_docs_to_gh_pages.yaml
@@ -1,0 +1,48 @@
+# Deploy CMF mkdocs-based documentation to GitHub pages. The CMF docs need to be built first (because we automatically
+# build API documentation pages).
+# https://github.com/peaceiris/actions-gh-pages
+
+name: Build CMF Docs & Deploy to GitHub pages
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "docs/**"
+      - ".github/workflows/deploy_docs.yml"
+
+jobs:
+  deploy-docs:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Setup Python
+        uses: actions/setup-python@v3
+        with:
+          python-version: "3.8"
+
+      - name: Install Python dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r docs/requirements.txt
+
+      - name: Build Docs
+        working-directory: './'
+        run: |
+          mkdocs build --theme material --site-dir ../site/
+          rm -r ../site/_src
+
+      - name: Deploy to GitHub Pages
+        # This step will deploy the generated documentation to `gh-pages` branch.
+        uses: peaceiris/actions-gh-pages@v3.9.0
+        with:
+          user_name: "github-actions[bot]"
+          user_email: "github-actions[bot]@users.noreply.github.com"
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ../site
+          allow_empty_commit: true


### PR DESCRIPTION
This commit adds a new GitHub workflow that builds the CMF documentation and deploys it with the GitHub pages. This workflow runs whenever documentation files in `docs/` are updated, or when source files used in generating public API are changed.