### PR TITLE
Change the main branch name for the "build docs" workflow.

### DIFF
--- a/.github/workflows/deploy_docs_to_gh_pages.yaml
+++ b/.github/workflows/deploy_docs_to_gh_pages.yaml
@@ -7,7 +7,7 @@ name: Build CMF Docs & Deploy to GitHub pages
 on:
   push:
     branches:
-      - main
+      - master
     paths:
       - ".github/workflows/deploy_docs_to_gh_pages.yaml"    # The workflow file itself.
       - "docs/**"                                           # Documentation files


### PR DESCRIPTION
BugFix to change the main branch name for the "Build CMF Docs & Deploy to GitHub pages" GitHub workflow.