### PR TITLE
BigFix: use single quotes in GitHub workflow expressions

### DIFF
--- a/.github/workflows/deploy_docs_to_gh_pages.yaml
+++ b/.github/workflows/deploy_docs_to_gh_pages.yaml
@@ -9,15 +9,15 @@ on:
     branches:
       - master
     paths:
-      - ".github/workflows/deploy_docs_to_gh_pages.yaml"    # The workflow file itself.
-      - "docs/**"                                           # Documentation files
-      - "!docs/_src/**"                                     #   but exclude this one (raw resources for docs).
-      - "cmflib/cmf.py"                                     # Public API documentation.
+      - '.github/workflows/deploy_docs_to_gh_pages.yaml'    # The workflow file itself.
+      - 'docs/**'                                           # Documentation files
+      - '!docs/_src/**'                                     #   but exclude this one (raw resources for docs).
+      - 'cmflib/cmf.py'                                     # Public API documentation.
 
 jobs:
   deploy-docs-to-gh-pages:
     # Do not run on forked repositories.
-    if: github.repository_owner == "HewlettPackard"
+    if: github.repository_owner == 'HewlettPackard'
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -28,7 +28,7 @@ jobs:
       - name: Setup Python Environment
         uses: actions/setup-python@v3
         with:
-          python-version: "3.8"
+          python-version: '3.8'
 
       - name: Install Python Dependencies
         run: |
@@ -47,8 +47,8 @@ jobs:
         # This step will deploy the generated documentation to `gh-pages` branch.
         uses: peaceiris/actions-gh-pages@v3.9.0
         with:
-          user_name: "github-actions[bot]"
-          user_email: "github-actions[bot]@users.noreply.github.com"
+          user_name: 'github-actions[bot]'
+          user_email: 'github-actions[bot]@users.noreply.github.com'
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ../site
           allow_empty_commit: true


### PR DESCRIPTION
Turns out GitHub actions only support the use of single quotes for strings in expressions.