### PR TITLE
Cmf integrations with external frameworks [WIP - need feedback and review]

### DIFF
--- a/cmflib/callback.py
+++ b/cmflib/callback.py
@@ -1,0 +1,150 @@
+import abc
+import typing as t
+from enum import Enum
+from ml_metadata.proto import metadata_store_pb2 as mlpb
+
+
+class ArtifactEvent(Enum):
+    """A helper class to work with Cmf's and MLMD's event types (input / output)"""
+
+    CONSUMED = 1
+    """Event type: 'input'"""
+    PRODUCED = 2
+    """Event type: 'output'"""
+
+    @classmethod
+    def from_string(cls, event: str) -> 'ArtifactEvent':
+        """Convert MLMD's event string to this enum."""
+        event = event.lower()
+        if event == 'input':
+            return ArtifactEvent.CONSUMED
+        if event == 'output':
+            return ArtifactEvent.PRODUCED
+        raise ValueError(f"Invalid artifact event: {event}. Valid values are (input, output).")
+
+    def to_mlmd_string(self) -> str:
+        """Convert this enum to MLMD's string."""
+        if self == ArtifactEvent.CONSUMED:
+            return 'input'
+        return 'output'
+
+
+class Artifact:
+    """Base class for all artifacts that Cmf uses to communicate with its subscribers (via callback mechanism).
+
+    TODO: Needs a little refactoring (remove `event` parameter, maybe replace execution_id with execution)
+    """
+    type: str = 'artifact'
+    """String identifier of this artifact."""
+
+    def __init__(self, uri: str, event: str, execution_id, parent_context: mlpb.Context, custom_props: t.Dict,
+                 execution_label_props: t.Dict) -> None:
+        self.uri: str = uri
+        self.event: str = event.lower()
+        self.execution_id = execution_id
+        self.parent_context: mlpb.Context = parent_context
+        self.custom_props: t.Dict = custom_props
+        self.execution_label_props: t.Dict = execution_label_props
+
+
+class Dataset(Artifact):
+    """Machine learning dataset."""
+    type: str = 'dataset'
+
+    def __init__(self, name: str, url: str, uri: str, event: str, execution_id, parent_context: mlpb.Context,
+                 custom_props: t.Dict, execution_label_props: t.Dict) -> None:
+        super().__init__(uri, event, execution_id, parent_context, custom_props, execution_label_props)
+        self.url: str = url
+        self.name: str = name
+
+
+class Model(Artifact):
+    """Machine learning model."""
+    type: str = 'model'
+
+    def __init__(self, model_uri: str, uri: str, event: str, execution_id, parent_context: mlpb.Context,
+                 custom_props: t.Dict, execution_label_props: t.Dict) -> None:
+        super().__init__(uri, event, execution_id, parent_context, custom_props, execution_label_props)
+        self.model_uri: str = model_uri
+
+
+class ExecutionMetrics(Artifact):
+    """Stage-level performance metrics (those that are reported at the end of a stage, e.g., test accuracy)."""
+    type: str = 'execution_metrics'
+
+    def __init__(self, metrics_name: str, uri: str, event: str, execution_id, parent_context: mlpb.Context,
+                 custom_props: t.Dict, execution_label_props: t.Dict) -> None:
+        super().__init__(uri, event, execution_id, parent_context, custom_props, execution_label_props)
+        self.metrics_name: str = metrics_name
+
+
+class Callback:
+    """Base class for Cmf callbacks."""
+
+    @abc.abstractmethod
+    def on_pipeline_context(self, name: str, id_, properties: t.Optional[t.Dict]) -> None:
+        """Is called when a new or existing pipeline becomes available."""
+        ...
+
+    @abc.abstractmethod
+    def on_stage_context(self, name: str, id_, properties: t.Optional[t.Dict],
+                         pipeline_context: mlpb.Context) -> None:
+        """Is called when a new or existing stage context becomes available."""
+        ...
+
+    @abc.abstractmethod
+    def on_stage_execution(self, name: str, id_, properties: t.Optional[t.Dict],
+                           stage_context: mlpb.Context, pipeline_context: mlpb.Context,
+                           is_new: bool) -> None:
+        """Is called when a new stage execution is created, or when properties of the existing one to be updated."""
+        ...
+
+    @abc.abstractmethod
+    def on_artifact_event(self, event: ArtifactEvent, artifact: Artifact) -> None:
+        """Is called when a new artifact is consumed or produced by a stage."""
+        ...
+
+
+class LifeCycleStageGuard(Callback):
+    """A helper callback to identify bugs related to improper use of the Cmf API.
+
+    TODO: work in progress.
+    """
+
+    NOT_INITIALIZED = 0
+    PIPELINE_CREATED = 1
+    CONTEXT_CREATED = 2
+    EXECUTION_CREATED = 3
+
+    def __init__(self) -> None:
+        self.stage = self.NOT_INITIALIZED
+
+    def on_pipeline_context(self, name: str, id_, properties: t.Optional[t.Dict]) -> None:
+        if self.stage != self.NOT_INITIALIZED:
+            print("[WARNING] transition to `PIPELINE_CREATED` is only allowed from `NOT_INITIALIZED` state.")
+        self.stage = self.PIPELINE_CREATED
+
+    def on_stage_context(self, name: str, id_, properties: t.Optional[t.Dict], pipeline_context: mlpb.Context) -> None:
+        if self.stage != self.PIPELINE_CREATED:
+            print("[WARNING] transition to `CONTEXT_CREATED` is only allowed from `PIPELINE_CREATED` state.")
+        self.stage = self.CONTEXT_CREATED
+
+    def on_stage_execution(self, name: str, id_, properties: t.Optional[t.Dict],
+                           stage_context: mlpb.Context, pipeline_context: mlpb.Context,
+                           is_new: bool) -> None:
+        if is_new:
+            if self.stage not in (self.CONTEXT_CREATED, self.EXECUTION_CREATED):
+                print("[WARNING] transition to `EXECUTION_CREATED` is only allowed from `CONTEXT_CREATED` or "
+                      "`EXECUTION_CREATED` states.")
+        else:
+            if self.stage != self.EXECUTION_CREATED:
+                print(
+                    f"[WARNING] execution update is allowed in `EXECUTION_CREATED` stage. Current stage = {self.stage}"
+                )
+        self.stage = self.EXECUTION_CREATED
+
+    def on_artifact_event(self, event: ArtifactEvent, artifact: Artifact) -> None:
+        if self.stage != self.EXECUTION_CREATED:
+            print(
+                f"[WARNING] artifact event is only allowed in `EXECUTION_CREATED` stage. Current stage is {self.stage}"
+            )

--- a/cmflib/integration/mlflow/__init__.py
+++ b/cmflib/integration/mlflow/__init__.py
@@ -1,0 +1,3 @@
+from ._mlflow import MLflowCallback
+
+__all__ = ['MLflowCallback']

--- a/cmflib/integration/mlflow/_mlflow.py
+++ b/cmflib/integration/mlflow/_mlflow.py
@@ -1,0 +1,100 @@
+import json
+import typing as t
+from cmflib.callback import (Callback, ArtifactEvent, Artifact)
+import mlflow
+import mlflow.entities
+from ml_metadata.proto import metadata_store_pb2 as mlpb
+
+
+__all__ = ['MLflowCallback']
+
+
+class MLflowCallback(Callback):
+    """Callback to report Cmf data to MLflow.
+
+    TODO: work in progress.
+    """
+    def __init__(self) -> None:
+        self.pipeline_run: t.Optional[mlflow.entities.Run] = None
+        self.stage_run: t.Optional[mlflow.entities.Run] = None
+
+    def on_pipeline_context(self, name: str, id_, properties: t.Optional[t.Dict]) -> None:
+        # End all active runs
+        while mlflow.active_run() is not None:
+            mlflow.end_run()
+
+        # Find or create and then start or resume a run for this pipeline.
+        runs: t.List[mlflow.entities.Run] = mlflow.search_runs(
+            filter_string=f"tags.cmf_id = {id_}", output_format='list'
+        )
+        pipeline_run_id: t.Optional[str] = runs[0].info.run_id if runs else None
+        self.pipeline_run = mlflow.start_run(
+            run_id=pipeline_run_id,
+            tags={'cmf_id': id_, 'cmf_name': name, 'cmf_type': 'pipeline'}
+        )
+        # Log pipeline properties as MLflow run parameters.
+        # TODO: are properties parameters or tags?
+        self._log_properties(self.pipeline_run.info.run_id, properties)
+
+    def on_stage_context(self, name: str, id_, properties: t.Optional[t.Dict], pipeline_context: mlpb.Context) -> None:
+        # Check that pipeline run is active now.
+        self._check_active_run(self.pipeline_run)
+
+        # Add new parameter to pipeline run with information for this stage.
+        client = mlflow.tracking.MlflowClient()
+        client.log_param(
+            run_id=self.pipeline_run.info.run_id,
+            key=f'cmf_stage_{name}',
+            value=json.dumps({'name': name, 'id': id_, 'properties': properties or {}})
+        )
+
+    def on_stage_execution(self, name: str, id_, properties: t.Optional[t.Dict],
+                           stage_context: mlpb.Context, pipeline_context: mlpb.Context,
+                           is_new: bool) -> None:
+        if is_new:
+            if self.stage_run is not None:
+                self._check_active_run(self.stage_run)
+                mlflow.end_run()
+                self.stage_run = None
+            self._check_active_run(self.pipeline_run)
+            self.stage_run = mlflow.start_run(
+                tags={'cmf_id': id_, 'cmf_name': name, 'cmf_type': 'stage', 'cmf_stage_context_id': stage_context.id,
+                      'cmf_pipeline_context_id': pipeline_context.id},
+                nested=True
+            )
+        self._check_active_run(self.stage_run)
+        self._log_properties(self.stage_run.info.run_id, properties)
+
+    def on_artifact_event(self, event: ArtifactEvent, artifact: Artifact) -> None:
+        # Check that active run is the expected stage run
+        self._check_active_run(self.stage_run)
+        # The `mlmd_event` variable is either `input` or `output`
+        mlmd_event = event.to_mlmd_string()
+        events: t.List[t.Dict] = json.loads(self.stage_run.data.tags.get(mlmd_event, '[]'))
+        # Update run's tag
+        if event == ArtifactEvent.CONSUMED:
+            event_info = {'uri': artifact.uri}
+        else:
+            event_info = {
+                'type': artifact.type, 'uri': artifact.uri, 'properties': artifact.custom_props or {}
+            }
+
+        events.append(event_info)
+        mlflow.tracking.MlflowClient().set_tag(self.stage_run.info.run_id, mlmd_event, json.dumps(events))
+        self.stage_run = mlflow.get_run(self.stage_run.info.run_id)
+
+    @staticmethod
+    def _log_properties(run_id: str, properties: t.Optional[t.Dict]) -> None:
+        """Log properties for the given MLflow run."""
+        if properties:
+            client = mlflow.tracking.MlflowClient()
+            for name, value in properties.items():
+                client.log_param(run_id, name, value)
+
+    @staticmethod
+    def _check_active_run(expected_run: t.Optional[mlflow.entities.Run]) -> None:
+        """Check that expected and active runs exist and are the same."""
+        active_run: t.Optional[mlflow.ActiveRun] = mlflow.active_run()
+        assert active_run is not None, "MLflow active run must be active now."
+        assert expected_run is not None, "Expected run must be known."
+        assert expected_run.info.run_id == active_run.info.run_id, "Expected and active runs do not match."

--- a/cmflib/integration/neo4j/__init__.py
+++ b/cmflib/integration/neo4j/__init__.py
@@ -1,0 +1,3 @@
+from ._neo4j import Neo4JCallback
+
+__all__ = ['Neo4JCallback']

--- a/cmflib/integration/neo4j/_driver.py
+++ b/cmflib/integration/neo4j/_driver.py
@@ -18,9 +18,10 @@ import typing as t
 import re
 from ml_metadata.proto import metadata_store_pb2 as mlpb
 
+__all__ = ['GraphDriver']
+
 
 class GraphDriver:
-
     def __init__(self, uri, user, password):
         self.driver = GraphDatabase.driver(uri, auth=(user, password))
         self.pipeline_id = None

--- a/cmflib/integration/neo4j/_neo4j.py
+++ b/cmflib/integration/neo4j/_neo4j.py
@@ -1,0 +1,120 @@
+import os
+import typing as t
+from cmflib.callback import Callback, ArtifactEvent, Artifact, Dataset, Model, ExecutionMetrics
+from ml_metadata.proto import metadata_store_pb2 as mlpb
+from ._driver import GraphDriver
+
+__all__ = ['Neo4JCallback']
+
+
+class Neo4JCallback(Callback):
+    """Callback to report Cmf data to Neo4J framework."""
+
+    def __init__(self, uri: t.Optional[str], user: t.Optional[str], password: t.Optional[str]) -> None:
+        self.driver = GraphDriver(
+            uri or os.getenv('NEO4J_URI', ''),
+            user or os.getenv('NEO4J_USER_NAME', ''),
+            password or os.getenv('NEO4J_PASSWD', '')
+        )
+        self.input_artifacts: t.List[t.Dict] = []
+        self.execution_name: t.Optional[str] = None
+        self.execution_command: t.Optional[str] = None
+
+    def on_pipeline_context(self, name: str, id_, properties: t.Optional[t.Dict]) -> None:
+        self.driver.create_pipeline_node(name, id_, properties)
+
+    def on_stage_context(self, name: str, id_, properties: t.Optional[t.Dict],
+                         pipeline_context: mlpb.Context) -> None:
+        self.driver.create_stage_node(name, pipeline_context, id_, properties)
+
+    def on_stage_execution(self, name: str, id_, properties: t.Optional[t.Dict],
+                           stage_context: mlpb.Context, pipeline_context: mlpb.Context,
+                           is_new: bool) -> None:
+        if is_new:
+            self.input_artifacts.clear()
+            self.execution_name = name
+            self.execution_command = stage_context.properties["Execution"].string_value
+        else:
+            # This is an update for current execution
+            ...
+
+        self.driver.create_execution_node(
+            name, stage_context.id, pipeline_context, self.execution_command, id_, properties
+        )
+
+    def on_artifact_event(self, event: ArtifactEvent, artifact: Artifact) -> None:
+        if isinstance(artifact, Dataset):
+            self._on_dataset(event, artifact)
+        elif isinstance(artifact, Model):
+            self._on_model(event, artifact)
+        elif isinstance(artifact, ExecutionMetrics):
+            self._on_execution_metrics(event, artifact)
+        else:
+            raise ValueError(f"Unsupported artifact: {artifact}")
+
+    def _on_dataset(self, event: ArtifactEvent, dataset: Dataset) -> None:
+        self.driver.create_dataset_node(
+            dataset.name, dataset.url, dataset.uri, dataset.event,
+            dataset.execution_id, dataset.parent_context, dataset.custom_props
+        )
+        artifact_info = {
+            "Name": dataset.name,
+            "Path": dataset.url,
+            "URI": dataset.uri,
+            "Event": dataset.event,
+            "Execution_Name": self.execution_name,
+            "Type": "Dataset",
+            "Execution_Command": self.execution_command,
+            "Pipeline_Id": dataset.parent_context.id,
+            "Pipeline_Name": dataset.parent_context.name
+        }
+        if event == ArtifactEvent.CONSUMED:
+            self.input_artifacts.append(artifact_info)
+            self.driver.create_execution_links(dataset.uri, dataset.name, "Dataset")
+        else:
+            self.driver.create_artifact_relationships(
+                self.input_artifacts, artifact_info, dataset.execution_label_props
+            )
+
+    def _on_model(self, event: ArtifactEvent, model: Model) -> None:
+        self.driver.create_model_node(
+            model.model_uri, model.uri, model.event,
+            model.execution_id, model.parent_context, model.custom_props
+        )
+        artifact_info = {
+            "Name": model.model_uri,
+            "URI": model.uri,
+            "Event": model.event,
+            "Execution_Name": self.execution_name,
+            "Type": "Model",
+            "Execution_Command": self.execution_command,
+            "Pipeline_Id": model.parent_context.id,
+            "Pipeline_Name": model.parent_context.name
+        }
+        if event == ArtifactEvent.CONSUMED:
+            self.input_artifacts.append(artifact_info)
+            self.driver.create_execution_links(model.uri, model.model_uri, "Model")
+        else:
+            self.driver.create_artifact_relationships(
+                self.input_artifacts, artifact_info, model.execution_label_props
+            )
+
+    def _on_execution_metrics(self, event: ArtifactEvent, metrics: ExecutionMetrics) -> None:
+        assert event == ArtifactEvent.PRODUCED, "Should this assert be here?"
+        self.driver.create_metrics_node(
+            metrics.metrics_name, metrics.uri, metrics.event,
+            metrics.execution_id, metrics.parent_context, metrics.custom_props
+        )
+        artifact_info = {
+            "Name": metrics.metrics_name,
+            "URI": metrics.uri,
+            "Event": metrics.event,
+            "Execution_Name": self.execution_name,
+            "Type": "Metrics",
+            "Execution_Command": self.execution_command,
+            "Pipeline_Id": metrics.parent_context.id,
+            "Pipeline_Name": metrics.parent_context.name
+        }
+        self.driver.create_artifact_relationships(
+            self.input_artifacts, artifact_info, metrics.execution_label_props
+        )


### PR DESCRIPTION
This mechanism is based on `callbacks`. The Cmf init method accepts the list of callback instances that users can provide. Several callbacks include Neo4j (refactored existing implementation) and MLflow. These callbacks do not replace the core Cmf features. Instead, they allow to send Cmf data to someplace else.

Usage example:

    ```python
    from cmflib.cmf import Cmf
    from cmflib.integration.neo4j import Neo4JCallback
    from cmflib.integration.mlflow import MLflowCallback

    cmf = Cmf(
        filename='mlmd',
        pipeline_name='mnist',
        callbacks=[
            Neo4JCallback(),
            MLflowCallback()
        ]
    )
    ```

This opens up several opportunities, such as, for instance, making certain `cmflib` dependencies optional.