### PR TITLE
Adding flake8 rules to `pyproject.toml`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,3 +15,25 @@ classifiers = [
 [project.urls]
 "Homepage" = "https://github.com/HewlettPackard/cmf"
 "Bug Tracker" = "https://github.com/HewlettPackard/cmf/issues"
+
+[tool.flake8]
+max-line-length = 120
+
+exclude = [
+    './.git',
+    './.github',
+    './docs',
+    '__pycache__',
+    '.pytest_cache',
+]
+
+# D100 Missing docstring in public module (disabled temporarily)
+ignore = ['D100']
+
+# D101 Missing docstring in public class
+# D102 Missing docstring in public method
+# D103 Missing docstring in public function
+# D104 Missing docstring in public package
+per-file-ignores = [
+     'test_*.py: D101, D102, D103, D104'
+]


### PR DESCRIPTION
To use flake8 with configuration stored in `pyproject.toml` file, the following packages need to be installed:

```shell
pip install flake8 Flake8-pyproject
```

Run flake8 checks against the source code (or integrate with your development environment):

```shell
flake8 ./examples/example-get-started
```