### PR TITLE
Fixing style warnings for `example-get-started` project.

### DIFF
--- a/examples/example-get-started/src/featurize.py
+++ b/examples/example-get-started/src/featurize.py
@@ -72,7 +72,7 @@ def featurize(input_dir: str, output_dir: str) -> None:
 
     os.makedirs(output_dir, exist_ok=True)
     output_ds = Dataset(train=os.path.join(output_dir, "train.pkl"), test=os.path.join(output_dir, "test.pkl"))
-    graph_env = os.getenv("NEO4J","False")
+    graph_env = os.getenv("NEO4J", "False")
     graph = True if graph_env == "True" or graph_env == "TRUE" else False
     metawriter = cmf.Cmf(filename="mlmd", pipeline_name="Test-env", graph=graph)
 

--- a/examples/example-get-started/src/parse.py
+++ b/examples/example-get-started/src/parse.py
@@ -59,7 +59,7 @@ def parse(input_file: str, output_dir: str) -> None:
     """
     params = yaml.safe_load(open("params.yaml"))["parse"]
     random.seed(params["seed"])
-    graph_env = os.getenv("NEO4J","False") 
+    graph_env = os.getenv("NEO4J", "False")
     graph = True if graph_env == "True" or graph_env == "TRUE" else False
     metawriter = cmf.Cmf(filename="mlmd", pipeline_name="Test-env", graph=graph)
     _ = metawriter.create_context(pipeline_stage="Prepare", custom_properties={"user-metadata1": "metadata_value"})

--- a/examples/example-get-started/src/test.py
+++ b/examples/example-get-started/src/test.py
@@ -46,7 +46,7 @@ def test(model_dir: str, dataset_dir: str, output_dir: str) -> None:
         prc=os.path.join(output_dir, 'prc.json'),
         roc=os.path.join(output_dir, 'roc.json')
     )
-    graph_env = os.getenv("NEO4J","False")
+    graph_env = os.getenv("NEO4J", "False")
     graph = True if graph_env == "True" or graph_env == "TRUE" else False
     metawriter = cmf.Cmf(filename="mlmd", pipeline_name="Test-env", graph=graph)
     _ = metawriter.create_context(pipeline_stage="Evaluate")

--- a/examples/example-get-started/src/train.py
+++ b/examples/example-get-started/src/train.py
@@ -37,7 +37,7 @@ def train(input_dir: str, output_dir: str) -> None:
         Output: ${output_dir}/model.pkl
     """
     params = yaml.safe_load(open("params.yaml"))["train"]
-    graph_env = os.getenv("NEO4J","False")
+    graph_env = os.getenv("NEO4J", "False")
     graph = True if graph_env == "True" or graph_env == "TRUE" else False
     metawriter = cmf.Cmf(filename="mlmd", pipeline_name="Test-env", graph=graph)
     _ = metawriter.create_context(pipeline_stage="Train")

--- a/examples/example-get-started/test-data-slice.py
+++ b/examples/example-get-started/test-data-slice.py
@@ -17,8 +17,6 @@
 from cmflib import cmf
 import random
 import pandas as pd
-import gzip
-import shutil
 import os
 import string
 from shutil import rmtree
@@ -38,8 +36,8 @@ def generate_dataset():
             string.ascii_letters + string.digits)
             for _ in range(100)]))
 
-    for i in range(1, 101):
-        with open(path + "/" + str(i) + ".txt", 'w') as f:
+    for _i in range(1, 101):
+        with open(path + "/" + str(_i) + ".txt", 'w') as f:
             index = random.randint(0, 3)
             f.write(msg[index])
 
@@ -63,7 +61,10 @@ for i in range(1, 3, 1):
     for _ in range(1, 20, 1):
         j = random.randrange(1, 100)
         print(folder_path + "/" + str(j) + ".txt")
-        dataslice.add_data(path=folder_path + "/" + str(j) + ".txt", custom_properties={"key1": "value1", "key2": "value2"})
+        dataslice.add_data(
+            path=folder_path + "/" + str(j) + ".txt",
+            custom_properties={"key1": "value1", "key2": "value2"}
+        )
     dataslice.commit()
 
 # Reading the files in the slice.


### PR DESCRIPTION
Using flake8 configuration from another PR #56 to fix python style warnings for the `example-get-started` example project.