### PR TITLE
Graph-like API to traverse CMF metadata

### DIFF
--- a/cmflib/cmfquery.py
+++ b/cmflib/cmfquery.py
@@ -15,8 +15,9 @@
 ###
 
 import json
-import typing as t
 import logging
+import typing as t
+
 import pandas as pd
 from ml_metadata.metadata_store import metadata_store
 from ml_metadata.proto import metadata_store_pb2 as mlpb
@@ -28,15 +29,13 @@ __all__ = ["CmfQuery"]
 logger = logging.getLogger(__name__)
 
 
-# TODO: Rename to CMF Client or just set CmfClient = CmfQuery
-
-
 class CmfQuery(object):
-    """CMF Query (client) communicates with MLMD database and implements basic search and retrieval functionality.
+    """CMF Query communicates with the MLMD database and implements basic search and retrieval functionality.
 
     Args:
         filepath: Path to the MLMD database file.
     """
+
     def __init__(self, filepath: str = "mlmd") -> None:
         config = mlpb.ConnectionConfig()
         config.sqlite.filename_uri = filepath
@@ -44,7 +43,7 @@ class CmfQuery(object):
 
     @staticmethod
     def _copy(source: t.Mapping, target: t.Optional[t.Dict] = None, key_mapper: t.Optional[t.Dict] = None) -> t.Dict:
-        """Create copy of `_copy` and return use, reuse `target` if not None.
+        """Create copy of `source` and return it, reuse `target` if not None.
 
         Args:
             source: Input dict-like object to create copy.
@@ -54,8 +53,10 @@ class CmfQuery(object):
         Returns:
             If `target` is not None, it is returned containing data from `source`. Else, new object is returned.
         """
-        target = target or {}
-        key_mapper = key_mapper or {}
+        if target is None:
+            target = {}
+        if key_mapper is None:
+            key_mapper = {}
 
         for key, value in source.items():
             if value.HasField("string_value"):
@@ -70,7 +71,9 @@ class CmfQuery(object):
         return target
 
     @staticmethod
-    def _transform_to_dataframe(node, d: t.Optional[t.Dict] = None) -> pd.DataFrame:
+    def _transform_to_dataframe(
+        node: t.Union[mlpb.Execution, mlpb.Artifact], d: t.Optional[t.Dict] = None
+    ) -> pd.DataFrame:
         """Transform MLMD entity `node` to pandas data frame.
 
         Args:
@@ -78,12 +81,52 @@ class CmfQuery(object):
             d: Pre-populated dictionary of KV-pairs to associate  with `node` (will become columns in output table).
         Returns:
             Pandas data frame with one row containing data from `node`.
+
+        TODO: (sergey) Overwriting `d` with key/values from `properties` and `custom_properties` is not safe, some
+              tests fail (`test_get_all_parent_executions`) - it happens to be the case that `id` gets overwritten. For
+              instance, this happens when artifact is of type Dataset, and custom_properties contain id equal to
+              `multi_nli`. Later, this `id` can be used to invoke other MLMD APIs and that fails.
+
+        TODO: (sergey) Maybe add prefix for properties and custom_properties keys?
         """
         if d is None:
-            d = {"id": node.id, "name": getattr(node, "name", "")}
+            d = {}
 
-        _ = CmfQuery._copy(node.properties, d)
-        _ = CmfQuery._copy(node.custom_properties, d)
+        keys_to_be_updated = set(d.keys()).intersection(node.properties.keys())
+        if keys_to_be_updated:
+            logger.warning(
+                "Unsafe OP detected for node (type=%s, id=%i): existing node keys (%s) will be updated from "
+                "node's `properties`.",
+                type(node),
+                node.id,
+                keys_to_be_updated,
+            )
+        if "id" in node.properties:
+            logger.warning(
+                "Unsafe OP detected for node (type=%s, id=%i): will update `id` from properties (value=%s)",
+                type(node),
+                node.id,
+                node.properties["id"],
+            )
+        d = CmfQuery._copy(node.properties, d)
+
+        keys_to_be_updated = set(d.keys()).intersection(node.properties.keys())
+        if keys_to_be_updated:
+            logger.warning(
+                "Unsafe OP detected for node (type=%s, id=%i): existing node keys (%s) will be updated from "
+                "node's `custom_properties`.",
+                type(node),
+                node.id,
+                keys_to_be_updated,
+            )
+        if "id" in node.custom_properties:
+            logger.warning(
+                "Unsafe OP detected for node (type=%s, id=%i): will update `id` from custom_properties (value=%s)",
+                type(node),
+                node.id,
+                node.properties["id"],
+            )
+        d = CmfQuery._copy(node.custom_properties, d)
 
         return pd.DataFrame(
             d,
@@ -117,6 +160,10 @@ class CmfQuery(object):
             name: Piepline name or None to return all pipelines.
         Returns:
             List of objects associated with pipelines.
+
+        TODO (sergey): Is `Parent_Context` value always used for pipelines?
+        TODO (sergey): Why `name` parameter when there's another method `_get_pipeline`?
+        TODO (sergey): Use `self.store.get_context_by_type_and_name` when name presents?
         """
         pipelines: t.List[mlpb.Context] = self.store.get_contexts_by_type("Parent_Context")
         if name is not None:
@@ -129,6 +176,8 @@ class CmfQuery(object):
             name: Pipeline name.
         Returns:
             A pipeline object if found, else None.
+
+        TODO (sergey): Use `self.store.get_context_by_type_and_name` instead calling self._get_pipelines?
         """
         pipelines: t.List = self._get_pipelines(name)
         if pipelines:
@@ -197,9 +246,9 @@ class CmfQuery(object):
     def _get_artifact(self, name: str) -> t.Optional[mlpb.Artifact]:
         """Return artifact with the given name or None.
 
-        TODO: Different artifact types may have the same name (see `get_artifacts_by_type`,
+        TODO: Different artifact types can have the same name (see `get_artifacts_by_type`,
               `get_artifact_by_type_and_name`).
-
+        TODO: (sergey) Use `self.store.get_artifacts` with list_options (filter_query)?
         Args:
             name: Artifact name.
         Returns:
@@ -218,6 +267,9 @@ class CmfQuery(object):
             execution_ids: List of execution identifiers to return output artifacts for.
         Returns:
             List of output artifact identifiers.
+
+        TODO: (sergey) The `test_get_one_hop_child_artifacts` prints the warning in this method (Multiple executions
+              claim the same output artifacts)
         """
         artifact_ids: t.List[int] = [
             event.artifact_id
@@ -246,7 +298,11 @@ class CmfQuery(object):
         return list(artifact_ids)
 
     def get_pipeline_names(self) -> t.List[str]:
-        """Return names of all pipelines in the MLMD database."""
+        """Return names of all pipelines.
+
+        Returns:
+            List of all pipeline names.
+        """
         return [ctx.name for ctx in self._get_pipelines()]
 
     def get_pipeline_id(self, pipeline_name: str) -> int:
@@ -262,7 +318,13 @@ class CmfQuery(object):
     def get_pipeline_stages(self, pipeline_name: str) -> t.List[str]:
         """Return list of pipeline stages for the pipeline with the given name.
 
+        Args:
+            pipeline_name: Name of the pipeline for which stages need to be returned.
+        Returns:
+            List of stage names associated with the given pipeline.
+
         TODO: Can there be multiple pipelines with the same name?
+        TODO: (sergey) not clear from method name that this method returns stage names
         """
         stages = []
         for pipeline in self._get_pipelines(pipeline_name):
@@ -271,6 +333,11 @@ class CmfQuery(object):
 
     def get_all_exe_in_stage(self, stage_name: str) -> t.List[mlpb.Execution]:
         """Return list of all executions for the stage with the given name.
+
+        Args:
+            stage_name: Name of the stage.
+        Returns:
+            List of executions for the given stage.
 
         TODO: Can stages from different pipelines have the same name?. Currently, the first matching stage is used to
               identify its executions. Also see "get_all_executions_in_stage".
@@ -284,6 +351,11 @@ class CmfQuery(object):
     def get_all_executions_in_stage(self, stage_name: str) -> pd.DataFrame:
         """Return executions of the given stage as pandas data frame.
 
+        Args:
+            stage_name: Stage name.
+        Returns:
+            Data frame with all executions associated with the given stage.
+
         TODO: Multiple stages with the same name? This method collects executions from all such stages. Also, see
               "get_all_exe_in_stage"
         """
@@ -292,7 +364,10 @@ class CmfQuery(object):
             for stage in self._get_stages(pipeline.id):
                 if stage.name == stage_name:
                     for execution in self._get_executions(stage.id):
-                        df = pd.concat([df, self._transform_to_dataframe(execution)], sort=True, ignore_index=True)
+                        ex_as_df: pd.DataFrame = self._transform_to_dataframe(
+                            execution, {"id": execution.id, "name": execution.name}
+                        )
+                        df = pd.concat([df, ex_as_df], sort=True, ignore_index=True)
         return df
 
     def get_artifact_df(self, artifact: mlpb.Artifact, d: t.Optional[t.Dict] = None) -> pd.DataFrame:
@@ -303,8 +378,12 @@ class CmfQuery(object):
             d: Optional initial content for data frame.
         Returns:
             A data frame with the single row containing attributes of this artifact.
+
+        TODO: (sergey) there are no "public" methods that return `mlpb.Artifact`.
+        TODO: (sergey) what's the  difference between this method and `get_artifact`?
         """
-        d = d or {}
+        if d is None:
+            d = {}
         d.update(
             {
                 "id": artifact.id,
@@ -320,7 +399,11 @@ class CmfQuery(object):
     def get_all_artifacts(self) -> t.List[str]:
         """Return names of all artifacts.
 
-        TODO: Can multiple artifacts have the same name?
+        Returns:
+            List of all artifact names.
+
+        TODO: (sergey) Can multiple artifacts have the same name?
+        TODO: (sergey) Maybe rename to get_artifact_names (to be consistent with `get_pipeline_names`)?
         """
         return [artifact.name for artifact in self.store.get_artifacts()]
 
@@ -330,9 +413,11 @@ class CmfQuery(object):
         """Return artifact's data frame representation using artifact name.
 
         Args:
-            name: artifact name.
+            name: Artifact name.
         Returns:
-            Pandas data frame with one row.
+            Pandas data frame with one row containing attributes of this artifact.
+
+        TODO: (sergey) what's the  difference between this method and `get_artifact_df`?
         """
         artifact: t.Optional[mlpb.Artifact] = self._get_artifact(name)
         if artifact:
@@ -346,6 +431,8 @@ class CmfQuery(object):
             execution_id: Execution identifier.
         Return:
             Data frame containing input and output artifacts for the given execution, one artifact per row.
+
+        TODO: (sergey) briefly describe in what cases an execution may not have any artifacts.
         """
         df = pd.DataFrame()
         for event in self.store.get_events_by_execution_ids([execution_id]):
@@ -363,6 +450,9 @@ class CmfQuery(object):
             artifact_name: Artifact name.
         Returns:
             Pandas data frame containing stage executions, one execution per row.
+
+        TODO: (sergey) build list of dicts and then convert to data frame - will be quicker.
+        TODO: (sergey) can multiple contexts (pipeline and stage) be associated with one execution?
         """
         df = pd.DataFrame()
 
@@ -371,13 +461,14 @@ class CmfQuery(object):
             return df
 
         for event in self.store.get_events_by_artifact_ids([artifact.id]):
+            # TODO: (sergey) seems to be the same as stage below. What's this context for (stage or pipeline)?
             ctx = self.store.get_contexts_by_execution(event.execution_id)[0]
             linked_execution = {
                 "Type": "INPUT" if event.type == mlpb.Event.Type.INPUT else "OUTPUT",
                 "execution_id": event.execution_id,
                 "execution_name": self.store.get_executions_by_id([event.execution_id])[0].name,
                 "stage": self.store.get_contexts_by_execution(event.execution_id)[0].name,
-                "pipeline": self.store.get_parent_contexts_by_context(ctx.id)[0].name
+                "pipeline": self.store.get_parent_contexts_by_context(ctx.id)[0].name,
             }
             d1 = pd.DataFrame(
                 linked_execution,
@@ -401,17 +492,19 @@ class CmfQuery(object):
             return pd.DataFrame()
 
         # Get output artifacts of executions consumed the above artifact.
-        artifacts_ids = self._get_output_artifacts(
-            self._get_executions_by_input_artifact_id(artifact.id)
-        )
+        artifacts_ids = self._get_output_artifacts(self._get_executions_by_input_artifact_id(artifact.id))
 
         return self._as_pandas_df(
-            self.store.get_artifacts_by_id(artifacts_ids),
-            lambda _artifact: self.get_artifact_df(_artifact)
+            self.store.get_artifacts_by_id(artifacts_ids), lambda _artifact: self.get_artifact_df(_artifact)
         )
 
     def get_all_child_artifacts(self, artifact_name: str) -> pd.DataFrame:
         """Return all downstream artifacts starting from the given artifact.
+
+        Args:
+            artifact_name: Artifact name.
+        Returns:
+            Data frame containing all child artifacts.
 
         TODO: Only output artifacts or all?
         """
@@ -427,18 +520,19 @@ class CmfQuery(object):
         return df
 
     def get_one_hop_parent_artifacts(self, artifact_name: str) -> pd.DataFrame:
-        """Return input artifacts for the execution that produced the given artifact."""
+        """Return input artifacts for the execution that produced the given artifact.
+
+        Args:
+            artifact_name
+        """
         artifact: t.Optional = self._get_artifact(artifact_name)
         if not artifact:
             return pd.DataFrame()
 
-        artifact_ids = self._get_input_artifacts(
-            self._get_executions_by_output_artifact_id(artifact.id)
-        )
+        artifact_ids: t.List[int] = self._get_input_artifacts(self._get_executions_by_output_artifact_id(artifact.id))
 
         return self._as_pandas_df(
-            self.store.get_artifacts_by_id(artifact_ids),
-            lambda _artifact: self.get_artifact_df(_artifact)
+            self.store.get_artifacts_by_id(artifact_ids), lambda _artifact: self.get_artifact_df(_artifact)
         )
 
     def get_all_parent_artifacts(self, artifact_name: str) -> pd.DataFrame:
@@ -459,7 +553,7 @@ class CmfQuery(object):
 
     def get_all_parent_executions(self, artifact_name: str) -> pd.DataFrame:
         """Return all executions that produced upstream artifacts for the given artifact."""
-        parent_artifacts = self.get_all_parent_artifacts(artifact_name)
+        parent_artifacts: pd.DataFrame = self.get_all_parent_artifacts(artifact_name)
 
         execution_ids = set(
             event.execution_id
@@ -469,10 +563,10 @@ class CmfQuery(object):
 
         return self._as_pandas_df(
             self.store.get_executions_by_id(execution_ids),
-            lambda _execution: self._transform_to_dataframe(_execution)
+            lambda _exec: self._transform_to_dataframe(_exec, {"id": _exec.id, "name": _exec.name}),
         )
 
-    def find_producer_execution(self, artifact_name: str) -> t.Optional[object]:
+    def find_producer_execution(self, artifact_name: str) -> t.Optional[mlpb.Execution]:
         """Return execution that produced the given artifact.
 
         TODO: how come one artifact can have multiple producer executions?
@@ -488,9 +582,7 @@ class CmfQuery(object):
             if event.type == mlpb.Event.OUTPUT
         )
         if not executions_ids:
-            logger.debug(
-                "No producer execution exists for artifact (name=%s, id=%s).", artifact.name, artifact.id
-            )
+            logger.debug("No producer execution exists for artifact (name=%s, id=%s).", artifact.name, artifact.id)
             return None
 
         executions: t.List[mlpb.Execution] = self.store.get_executions_by_id(executions_ids)
@@ -501,7 +593,8 @@ class CmfQuery(object):
         if len(executions) >= 2:
             logger.debug(
                 "Multiple executions (ids=%s) claim artifact (name=%s) as output.",
-                [e.id for e in executions], artifact.name
+                [e.id for e in executions],
+                artifact.name,
             )
 
         return executions[0]
@@ -547,8 +640,9 @@ class CmfQuery(object):
             if "properties" in _attrs:
                 _attrs["properties"] = CmfQuery._copy(_attrs["properties"])
             if "custom_properties" in _attrs:
-                _attrs["custom_properties"] = CmfQuery._copy(_attrs["custom_properties"],
-                                                             key_mapper={"type": "user_type"})
+                _attrs["custom_properties"] = CmfQuery._copy(
+                    _attrs["custom_properties"], key_mapper={"type": "user_type"}
+                )
             return _attrs
 
         pipelines: t.List[t.Dict] = []
@@ -566,15 +660,14 @@ class CmfQuery(object):
                         {
                             "type": self.store.get_execution_types_by_id([execution.type_id])[0].name,
                             "name": execution.name if execution.name != "" else "",
-                            "events": []
-                        }
+                            "events": [],
+                        },
                     )
                     for event in self.store.get_events_by_execution_ids([execution.id]):
                         event_attrs = _get_node_attributes(event, {"artifacts": []})
                         for artifact in self.store.get_artifacts_by_id([event.artifact_id]):
                             artifact_attrs = _get_node_attributes(
-                                artifact,
-                                {"type": self.store.get_artifact_types_by_id([artifact.type_id])[0].name}
+                                artifact, {"type": self.store.get_artifact_types_by_id([artifact.type_id])[0].name}
                             )
                             event_attrs["artifacts"].append(artifact_attrs)
                         exec_attrs["events"].append(event_attrs)

--- a/cmflib/contrib/graph_api.py
+++ b/cmflib/contrib/graph_api.py
@@ -1,0 +1,402 @@
+import typing as t
+from typing import KT, Iterator, T_co, VT_co
+
+from cmfquery import CmfQuery
+from ml_metadata import ListOptions
+from ml_metadata.proto import metadata_store_pb2 as mlpb
+
+MlmdNode = t.Union[mlpb.Context, mlpb.Execution, mlpb.Artifact]
+Node = t.TypeVar("Node", bound="Base")
+
+
+_PIPELINE_CONTEXT_NAME = "Parent_Context"
+"""Name of a context type for pipelines."""
+
+_STAGE_CONTEXT_NAME = "Pipeline_Stage"
+"""Name of a context type for pipeline stages."""
+
+
+class Properties(t.Mapping):
+    """Read-only wrapper around MessageMapContainer that converts values to python types on the fly.
+    This is used to represent `properties` and `custom_properties` of all MLMD nodes (pipelines, stages, executions
+    and artifacts).
+    """
+
+    def __init__(self) -> None:
+        self._properties: t.Optional[t.Mapping] = None
+        """This is really google.protobuf.pyext._message.MessageMapContainer that inherits from MutableMapping"""
+
+    def __str__(self) -> str:
+        return str({k: v for k, v in self.items()})
+
+    def __iter__(self) -> Iterator[T_co]:
+        for k in self._properties.keys():
+            yield k
+
+    def __len__(self) -> int:
+        return len(self._properties)
+
+    def __getitem__(self, __key: KT) -> VT_co:
+        return get_python_value(self._properties[__key])
+
+
+class Base:
+    """Base class for wrappers that provide user-friendly API for MLMD's pipelines, stages, executions and artifacts.
+
+    Instance of child classes are not supposed to be directly created by users, so class members are "protected".
+    """
+
+    def __init__(self) -> None:
+        self._db: t.Optional[CmfQuery] = None
+        """Data access layer for MLMD."""
+
+        self._node: t.Optional[MlmdNode] = None
+        """Reference to an entity in MLMD that this class wraps."""
+
+    def __str__(self) -> str:
+        return (
+            f"{self.__class__.__name__}(id={self.id}, name={self.name}, properties={self.properties}, "
+            f"custom_properties={self.custom_properties})"
+        )
+
+    @property
+    def id(self) -> int:
+        return self._node.id
+
+    @property
+    def name(self) -> str:
+        return self._node.name
+
+    @property
+    def properties(self) -> Properties:
+        _properties = Properties()
+        _properties._properties = self._node.properties
+        return _properties
+
+    @property
+    def custom_properties(self) -> Properties:
+        _properties = Properties()
+        _properties._properties = self._node.custom_properties
+        return _properties
+
+    # @property
+    # def type_id(self) -> int:
+    #     return self._node.type_id
+
+    # @property
+    # def type(self) -> str:
+    #     return self._node.type
+
+    # @property
+    # def external_id(self) -> id:
+    #     return self._node.external_id
+
+    @classmethod
+    def _create(cls, db: CmfQuery, node: MlmdNode, attrs: t.Optional[t.Dict] = None) -> Node:
+        """Create class instance (users are not supposed to call this method by themselves).
+        Args:
+            db: Data access layer.
+            node: MLMD's node.
+            attrs: Optional attributes to set on newly created class instance (with `setattr` function).
+        Returns:
+            Instance of one of child classes.
+        """
+        obj = cls()
+        obj._db = db
+        obj._node = node
+        if attrs:
+            for name, value in attrs.items():
+                setattr(obj, name, value)
+        return obj
+
+    @classmethod
+    def _unique(cls, nodes: t.List[MlmdNode]) -> t.List[MlmdNode]:
+        """Return unique input elements in the input list using the `id` attribute as a unique key.
+        Args:
+            nodes: List of input elements.
+        Returns:
+            New list containing unique elements in `nodes`. Duplicates are identified using the `id` attribute.
+        """
+        ids = set(node.id for node in nodes)
+        return [node for node in nodes if node.id in ids]
+
+    @classmethod
+    def _one(cls, nodes: t.List[t.Any]) -> t.Any:
+        """Ensure input list contains exactly one element and return it.
+        Args:
+            nodes: List of input elements.
+        Returns:
+            First element in the list.
+        Raises:
+            ValueError error if length of `nodes` is not 1.
+        """
+        if len(nodes) != 1:
+            raise ValueError(f"List (len={len(nodes)}) expected to contain one element.")
+        return nodes[0]
+
+
+class Pipeline(Base):
+    """Class that represents AI pipelines."""
+
+    def __init__(self) -> None:
+        super().__init__()
+
+    def stages(self, query: t.Optional[str] = None) -> t.List["Stage"]:
+        """Return list of all stages in this pipeline."""
+        _mandatory_query = f"parent_contexts_a.name = '{self.name}'"
+        stage_contexts: t.List[mlpb.Context] = self._db._get_stages(pipeline_id=self.id)
+        return [Stage._create(self._db, ctx, {"_pipeline": self}) for ctx in stage_contexts]
+
+    def executions(self) -> t.List["Execution"]:
+        """Return list of all executions in this pipeline"""
+        executions: t.List[Execution] = []
+        for stage in self.stages():
+            executions.extend(stage.executions())
+        return executions
+
+    def artifacts(self) -> t.List["Artifact"]:
+        """Return list of all unique artifacts consumed and produced by this pipeline."""
+        artifacts: t.List[Artifact] = []
+        for execution in self.executions():
+            artifacts.extend(execution.inputs)
+            artifacts.extend(execution.outputs)
+        return self._unique(artifacts)
+
+
+class Stage(Base):
+    """Class that represents pipeline stages."""
+
+    def __init__(self) -> None:
+        super().__init__()
+
+        self._pipeline: t.Optional[Pipeline] = None
+        """Parent pipeline (lazily initialized)."""
+
+    @property
+    def pipeline(self) -> Pipeline:
+        """Return parent pipeline."""
+        if self._pipeline is None:
+            pipeline_context: mlpb.Context = self._one(
+                self._db.store.get_parent_contexts_by_context(context_id=self.id)
+            )
+            self._pipeline = Pipeline._create(self._db, pipeline_context)
+        return self._pipeline
+
+    def executions(self) -> t.List["Execution"]:
+        """Return list of all executions for this stage."""
+        executions: t.List[mlpb.Execution] = self._db._get_executions(stage_id=self.id)
+        return [Execution._create(self._db, execution, {"_stage": self}) for execution in executions]
+
+    def artifacts(self) -> t.List["Artifact"]:
+        """Return list of unique artifacts consumed and produced by this pipeline."""
+        artifacts: t.List[Artifact] = []
+        for execution in self.executions():
+            artifacts.extend(execution.inputs)
+            artifacts.extend(execution.outputs)
+        return self._unique(artifacts)
+
+
+class Execution(Base):
+    """Class that represents stage executions."""
+
+    def __init__(self) -> None:
+        super().__init__()
+
+        self._stage: t.Optional[Stage] = None
+        """Stage for this execution (lazily initialized)."""
+
+    @property
+    def stage(self) -> Stage:
+        if self._stage is None:
+            stage_context: mlpb.Context = self._one(self._db.store.get_contexts_by_execution(execution_id=self.id))
+            self._stage = Stage._create(self._db, stage_context)
+        return self._stage
+
+    @property
+    def inputs(self) -> t.List["Artifact"]:
+        """Return list of unique input artifacts for this execution."""
+        artifacts: t.List[mlpb.Artifact] = self._unique(
+            self._db.store.self.store.get_artifacts_by_id(self._db._get_input_artifacts([self.id]))
+        )
+        return [Artifact._create(self._db, artifact) for artifact in artifacts]
+
+    @property
+    def outputs(self) -> t.List["Artifact"]:
+        """Return list of unique output artifacts for this execution."""
+        artifacts: t.List[mlpb.Artifact] = self._unique(
+            self._db.store.self.store.get_artifacts_by_id(self._db._get_output_artifacts([self.id]))
+        )
+        return [Artifact._create(self._db, artifact) for artifact in artifacts]
+
+
+class Artifact(Base):
+    """Class that represents artifacts."""
+
+    def __init__(self) -> None:
+        super().__init__()
+
+        self._consumed_by: t.Optional[t.List[Execution]] = None
+        """List of unique executions that consumed this artifact (lazily initialized)."""
+
+        self._produced_by: t.Optional[t.List[Execution]] = None
+        """List of unique executions that produced this artifact (lazily initialized)."""
+
+    @property
+    def uri(self) -> str:
+        return self._node.uri
+
+    @property
+    def consumed_by(self) -> t.List[Execution]:
+        """Return all executions that have consumed this artifact."""
+        if self._consumed_by is None:
+            executions: t.List[mlpb.Execution] = self._unique(
+                self._db.store.get_executions_by_id(self._db._get_executions_by_input_artifact_id(artifact_id=self.id))
+            )
+            self._consumed_by = [Execution._create(self._db, execution) for execution in executions]
+        return self._consumed_by
+
+    @property
+    def produced_by(self) -> t.List[Execution]:
+        """Return all executions that have produced this artifact"""
+        if self._produced_by is None:
+            executions: t.List[mlpb.Execution] = self._unique(
+                self._db.store.get_executions_by_id(self._db._get_executions_by_output_artifact_id(artifact_id=self.id))
+            )
+            self._produced_by = [Execution._create(self._db, execution) for execution in executions]
+        return self._produced_by
+
+
+class MetadataStore:
+    """`Entry point` for traversing the MLMD database using graph-like API.
+
+    Many methods in this class support the `query` string argument. This is the same as the `filter_query` field in
+    the `ListOptions`, which is an input argument of several methods in MLMD that retrieve nodes of various types. The
+    not-so-detailed description of what this string can look like can be found here:
+        https://github.com/google/ml-metadata/blob/master/ml_metadata/proto/metadata_store.proto
+    Many MLMD node types have same attributes, such as `id`, `name`, `properties`, `custom_properties` and others. The
+    following functionality has been tested.
+        Common node attributes:
+            "id = 1113", "id != 1113", "id IN (1113, 1)", "name = 'text-generation'", "name != 'text-generation'",
+            "name LIKE '%-generation'"
+
+    Args:
+        file_path: Path to an MLMD database.
+
+    """
+
+    def __init__(self, file_path: str) -> None:
+        self._db = CmfQuery(filepath=file_path)
+        """Data access layer for MLMD."""
+
+    def _check_context_types(
+        self,
+        contexts: t.List[mlpb.Context],
+        type_name: str,
+    ):
+        ctx_type: mlpb.ContextType = self._db.store.get_context_type(type_name)
+        for context in contexts:
+            if context.type_id != ctx_type.id:
+                raise ValueError(
+                    f"MLMD query returned contexts of the wrong type (actual_type_id={context.type_id}, "
+                    f"expected_type_id={ctx_type.id}). "
+                    f"Did you forget to specify the type as part of the query (type = '{type_name}')?"
+                )
+
+    def _search_contexts(
+        self, ctx_type_name: str, ctx_wrapper_cls: t.Type[t.Union["Pipeline", "Stage"]], query: t.Optional[str] = None
+    ) -> t.Union[t.List["Pipeline"], t.List["Stage"]]:
+        if query is None:
+            query = f"type = '{ctx_type_name}'"
+        contexts: t.List[mlpb.Context] = self._db.store.get_contexts(self.list_options(query))
+        self._check_context_types(contexts, ctx_type_name)
+        return [ctx_wrapper_cls._create(self._db, ctx) for ctx in contexts]
+
+    def pipelines(self, query: t.Optional[str] = None) -> t.List["Pipeline"]:
+        """Retrieve pipelines.
+        Pipelines are represented as contexts in MLMD with type attributed equal to `Parent_Context`.
+        Args:
+            query: The `filter_query` field for the `ListOptions` instance. See class doc strings for examples.
+        Raises:
+            ValueError when query is present, and results in contexts that are not pipelines.
+        Known limitations:
+            When query is not None, it must define type (type = 'Parent_Context'), when ID is present this may not be
+            required though.
+            No filtering is supported by stage ID (no big deal).
+        Query examples:
+            Filtering by basic node attributes.
+                See class foc strings.
+            Filter by stage attributes (child_contexts_a is the stage context). There is a bug that prevents using the
+            ID for filtering by stage ID. It's fixed in MLMD version 1.14.0 (CMF uses the earlier version).
+                "child_contexts_a.name LIKE 'text-generation/%'"
+        """
+        return self._search_contexts(_PIPELINE_CONTEXT_NAME, Pipeline, query)
+
+    def stages(self, query: t.Optional[str] = None) -> t.List["Stage"]:
+        """Retrieve stages.
+        Stages are represented as contexts in MLMD with type attributed equal to `Pipeline_Stage`.
+        Args:
+            query: The `filter_query` field for the `ListOptions` instance. See class doc strings for examples.
+        Raises:
+            ValueError when query is present, and results in contexts that are not stages.
+        Known limitations:
+            When query is not None, it must define type (type = 'Stage_Context'), when ID is present this may not be
+            required though.
+            No filtering is supported by pipeline ID (pretty significant feature).
+        Query examples:
+            Filtering by basic node attributes
+                See class foc strings.
+            Filter by pipeline attributes (parent_contexts_a is the pipeline context). There is a bug that prevents
+            using the ID for filtering by pipeline ID. It's fixed in MLMD version 1.14.0 (CMF uses the earlier version).
+                "parent_contexts_a.name = 'text-classification'", "parent_contexts_a.name LIKE '%-generation'",
+                "parent_contexts_a.type = 'Parent_Context'"
+        """
+        return self._search_contexts(_STAGE_CONTEXT_NAME, Stage, query)
+
+    def executions(self) -> t.List["Execution"]:
+        """Retrieve stage executions.
+        See `pipelines` method for more details.
+        """
+        executions: t.List[mlpb.Execution] = self._db.store.get_executions()
+        return [Execution._create(self._db, execution) for execution in executions]
+
+    def artifacts(self, query: t.Optional[str] = None) -> t.List["Artifact"]:
+        """
+        # Find artifact with this ID
+            id = 1315
+        # Find artifacts with a particular ArtifactType
+            type = 'Model'
+            type = 'Dataset'
+        # Find artifacts using pattern matching
+            name LIKE 'models/%'
+            name LIKE '%falcon%'
+            name LIKE 'datasets/%'
+        # Search using properties and custom_properties:
+            properties.url.string_value LIKE '%a655dead548f56fe3409321b3569a3%'
+            properties.pipeline_tag.string_value = 'text-classification'
+            custom_properties.pipeline_tag.string_value = 'text-classification'
+        """
+        artifacts: t.List[mlpb.Artifact] = self._db.store.get_artifacts(self.list_options(query))
+        return [Artifact._create(self._db, artifact) for artifact in artifacts]
+
+    @staticmethod
+    def list_options(query: t.Optional[str] = None) -> t.Optional[ListOptions]:
+        list_options: t.Optional[ListOptions] = None
+        if query:
+            list_options = ListOptions(filter_query=query)
+        return list_options
+
+
+def get_python_value(value: mlpb.Value) -> t.Union[str, int, float]:
+    """Convert MLMD value to a python value.
+    Args:
+        value: MLMD value.
+    Returns:
+        Python value.
+    """
+    if value.HasField("string_value"):
+        return value.string_value
+    elif value.HasField("int_value"):
+        return value.int_value
+    elif value.HasField("double_value"):
+        return value.double_value
+    raise NotImplementedError("Only string, int and double fields are supported.")


### PR DESCRIPTION
# Related Issues / Pull Requests

This PR depends on #120.

# Description

The API implements graph-like API to traverse CMF metadata in a graph-like manner. The entry point is the
[MetadataStore](https://github.com/sergey-serebryakov/cmf/blob/31ad9e99bba4bf6c730bfe259f45c586329a3ca7/cmflib/contrib/graph_api.py#L269) class that retrieves from metadata store pipelines, stages, executions and artifacts. Users
can specify search query to specify what they want to return (the query is basically the value for the
`filter_query` parameter of the `ListOptions` class ML Metadata (MLMD) library).

Each node mentioned above ([pipeline](https://github.com/sergey-serebryakov/cmf/blob/31ad9e99bba4bf6c730bfe259f45c586329a3ca7/cmflib/contrib/graph_api.py#L138), [stages](https://github.com/sergey-serebryakov/cmf/blob/31ad9e99bba4bf6c730bfe259f45c586329a3ca7/cmflib/contrib/graph_api.py#L166), [executions](https://github.com/sergey-serebryakov/cmf/blob/31ad9e99bba4bf6c730bfe259f45c586329a3ca7/cmflib/contrib/graph_api.py#L199) and [artifacts](https://github.com/sergey-serebryakov/cmf/blob/31ad9e99bba4bf6c730bfe259f45c586329a3ca7/cmflib/contrib/graph_api.py#L232)) has its own Python wrapper class that
provides developer-friendly API to access node's parameters and travers graph of machine learning concepts (e.g.,
get all stages of a pipeline or get all executions of a stage).

The graph API also provides the [Properties](https://github.com/sergey-serebryakov/cmf/blob/31ad9e99bba4bf6c730bfe259f45c586329a3ca7/cmflib/contrib/graph_api.py#L19) wrapper for MLMD's `properties` and `custom_properties` nodes' fields.
This wrapper implements the `Mapping` API and automatically converts MLMD's values to Python values on the fly.

Include a brief summary of the proposed changes.

# What changes are proposed in this pull request?

- [ ] Bug fix (non-breaking change which fixes an issue).
- [x] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected; for instance, 
      examples in this repository need to be updated too).
- [ ] This change requires a documentation update.

# Checklist:

- [x] My code follows the style guidelines of this project (PEP-8 with Google-style docstrings).
- [ ] My code modifies existing public API, or introduces new public API, and I updated or wrote docstrings that
      uses Google-style formatting and any other formatting that is supported by mkdocs and plugins this project
      uses.
- [x] I have commented my code.
- [ ] My code requires documentation updates, and I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
