### PR TITLE
Bug fix for cmfquery changes 

### DIFF
--- a/server/app/get_data.py
+++ b/server/app/get_data.py
@@ -26,11 +26,9 @@ def get_artifacts(mlmdfilepath, pipeline_name, data):  # get_artifacts return va
         if name==pipeline_name:
             stages = query.get_pipeline_stages(name)
             for stage in stages:
-                executions = query.get_all_executions_in_stage(stage)
-                dict_executions = executions.to_dict("dict")  # converting it to dictionary
-                for id in dict_executions["id"].values():
-                    identifiers.append(id)
-                identifiers.append(dict_executions["id"][0])
+                executions = query.get_all_exe_in_stage(stage)
+                for exe in executions:
+                    identifiers.append(exe.id)
     name = []
     url = []
     df = pd.DataFrame()
@@ -64,7 +62,6 @@ def create_unique_executions(server_store_path, req_info):
         for stage in stages:
             executions = []
             executions = query.get_all_executions_in_stage(stage)
-            #print(executions)
             for i in executions.index:                
                 for uuid in executions['Execution_uuid'][i].split(","):
                     executions_server.append(uuid)


### PR DESCRIPTION
# Related Issues / Pull Requests

This fix addresses the following concerns 
1. example_get_started script fails in the query state
2. cmf gui does not display artifacts and executions and fails with stack trace

# Description

* Removed adding prefix to properties and custom_properties as the names gets propogated to gui. would need additional code changes in gui to not display this prefix. Dropping it now. Will revisit later (if needed)
* json file created in client side was not formatted correctly. Events where having an array of artifacts, which is not needed as every event is associated only with a single event. Having the array breaks the server side code. 

* Artifact types were not getting propogated as the type was getting overwritten with empty string

# What changes are proposed in this pull request?

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected; for instance, 
      examples in this repository need to be updated too).
- [ ] This change requires a documentation update.

# Checklist:

- [ ] My code follows the style guidelines of this project (PEP-8 with Google-style docstrings).
- [ ] My code modifies existing public API, or introduces new public API, and I updated or wrote docstrings that
      uses Google-style formatting and any other formatting that is supported by mkdocs and plugins this project
      uses.
- [ ] I have commented my code.
- [ ] My code requires documentation updates, and I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
