### PR TITLE
making changes to 'cmf artifact push' to include external artifacts

### DIFF
--- a/cmflib/commands/artifact/push.py
+++ b/cmflib/commands/artifact/push.py
@@ -17,6 +17,7 @@
 #!/usr/bin/env python3
 import argparse
 import os
+import re
 
 from cmflib import cmfquery
 from cmflib.cli.command import CmdBase
@@ -96,8 +97,21 @@ class CmdArtifactPush(CmdBase):
                 # adding .dvc at the end of every file as it is needed for pull
                 artifacts['name'] = artifacts['name'].apply(lambda name: f"{name.split(':')[0]}.dvc")
                 names.extend(artifacts['name'].tolist())
-        file_set = set(names)
-        result = dvc_push(list(file_set))
+        final_list = []
+        for file in set(names):
+            # checking if the .dvc exists
+            if os.path.exists(file):
+                final_list.append(file)
+            # checking if the .dvc exists in user's project working directory
+            elif os.path.isabs(file):
+                    file = re.split("/",file)[-1]
+                    file = os.path.join(os.getcwd(), file)
+                    final_list.append(file)
+            else:
+                # not adding the .dvc to the final list in case .dvc doesn't exists in both the places
+                pass
+        print("file_set = ", final_list)
+        result = dvc_push(list(final_list))
         return result
       
 def add_parser(subparsers, parent_parser):

--- a/cmflib/commands/artifact/push.py
+++ b/cmflib/commands/artifact/push.py
@@ -106,11 +106,12 @@ class CmdArtifactPush(CmdBase):
             elif os.path.isabs(file):
                     file = re.split("/",file)[-1]
                     file = os.path.join(os.getcwd(), file)
-                    final_list.append(file)
+                    if os.path.exists(file):
+                        final_list.append(file)
             else:
                 # not adding the .dvc to the final list in case .dvc doesn't exists in both the places
                 pass
-        print("file_set = ", final_list)
+        #print("file_set = ", final_list)
         result = dvc_push(list(final_list))
         return result
       

--- a/cmflib/storage_backends/sshremote_artifacts.py
+++ b/cmflib/storage_backends/sshremote_artifacts.py
@@ -30,7 +30,6 @@ class SSHremoteArtifacts:
         object_name: str,
         download_loc: str,
     ):
-        remote_repo = dvc_config_op["remote.ssh-storage.url"]
         user = dvc_config_op["remote.ssh-storage.user"]
         password = dvc_config_op["remote.ssh-storage.password"]
         try:
@@ -40,18 +39,19 @@ class SSHremoteArtifacts:
             )  # this can lead to man in the middle attack, need to find another solution
             ssh.connect(host, username=user, password=password)
             sftp = ssh.open_sftp()
-
             dir_path = ""
+            # in case download_loc is absolute path like home/user/test/data.xml.gz
+            # we need to make this absolute path a relative one by removing first '/'
+            if os.path.isabs(download_loc):
+                download_loc = download_loc[1:]
             if "/" in download_loc:
                 dir_path, _ = download_loc.rsplit("/", 1)
             if dir_path != "":
-                # creates subfolders needed as per artifacts folder structure
-                os.makedirs(dir_path, mode=0o777, exist_ok=True)  
+                # creates subfolders needed as per artifacts' folder structure
+                os.makedirs(dir_path, mode=0o777, exist_ok=True) 
 
             response = ""
-
             abs_download_loc = os.path.abspath(os.path.join(current_directory, download_loc))
-
             """"
             if object_name ends with .dir - it is a directory.
             we download .dir object with 'temp_dir' and remove 
@@ -93,7 +93,6 @@ class SSHremoteArtifacts:
                         print(f"object {temp_object_name} downloaded at {temp_download_loc}.")
             else:
                 response = sftp.put(object_name, abs_download_loc)
-            
             if response:
                 stmt = f"object {object_name} downloaded at {abs_download_loc}."
                 return stmt


### PR DESCRIPTION
# Related Issues / Pull Requests

List all related issues and/or pull requests if there are any.

# Description

Include a brief summary of the proposed changes.

1. We can now use command 'cmf artifact push' to push any combination of external and internal artifacts. 
2. Resolved a bug for sshremote repo while pulling artifacts using 'cmf artifact pull' command. In this bug, we were unable to pull external artifact in case of sshremote repo.

# What changes are proposed in this pull request?

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected; for instance, 
      examples in this repository need to be updated too).
- [ ] This change requires a documentation update.

# Checklist:

- [ ] My code follows the style guidelines of this project (PEP-8 with Google-style docstrings).
- [ ] My code modifies existing public API, or introduces new public API, and I updated or wrote docstrings that
      uses Google-style formatting and any other formatting that is supported by mkdocs and plugins this project
      uses.
- [ ] I have commented my code.
- [ ] My code requires documentation updates, and I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
