### PR TITLE
Artifact lineage bug

### DIFF
--- a/server/app/query_artifact_lineage_d3tree.py
+++ b/server/app/query_artifact_lineage_d3tree.py
@@ -2,6 +2,7 @@ from cmflib.cmfquery import CmfQuery
 from collections import deque, defaultdict
 from typing import List, Dict, Any
 from server.app.utils import modify_arti_name
+import pandas as pd
 
 def query_artifact_lineage_d3tree(query: CmfQuery, pipeline_name: str, dict_of_art_ids: Dict) -> List[List[Dict[str, Any]]]:
     id_name = {}
@@ -9,11 +10,7 @@ def query_artifact_lineage_d3tree(query: CmfQuery, pipeline_name: str, dict_of_a
     skip_ids = set() # Skip environment and label artifacts
 
     # Get all artifact IDs that belong to the current pipeline
-    current_pipeline_artifact_ids = {
-        artifact_id
-        for df in dict_of_art_ids[pipeline_name].values()
-        for artifact_id in df["id"]
-    }
+    current_pipeline_artifact_ids = set(pd.concat(dict_of_art_ids[pipeline_name].values())["id"])
 
     for type_, df in dict_of_art_ids[pipeline_name].items():
         # Collect environment and label artifact IDs for skipping


### PR DESCRIPTION
# Related Issues / Pull Requests

Fixed bug - When multiple pipelines are pushed with same artifacts, Artifact lineage for pipelines is incomplete, while execution lineage and artifact-execution lineage are correct.

# Description

Steps to Reproduce:

1. Start the PostgreSQL server.

2. Push the mlmd_image file.

3. Push the Test-env MLMD file.

4. Navigate to the artifact lineage section in the GUI.

5. First, check the artifact lineage for Image.

6. Then, check the artifact lineage for Test-env.

# What changes are proposed in this pull request?

- [ ] Fixed artifact lineage bug when multiple pipelines are pushed - Filtered parent artifacts to only include those from the current pipeline
- [ ] Fixed labels should not be visible in artifact lineage

# Checklist:

- [ ] My code follows the style guidelines of this project (PEP-8 with Google-style docstrings).
- [ ] My code modifies existing public API, or introduces new public API, and I updated or wrote docstrings that
      uses Google-style formatting and any other formatting that is supported by mkdocs and plugins this project
      uses.
- [ ] I have commented my code.
- [ ] My code requires documentation updates, and I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
