### PR TITLE
Fix: Nginx large file upload limit

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -22,6 +22,7 @@ http {
     server {
         listen 80;
         server_name localhost;
+        client_max_body_size 0;  # 0 = no limit on request body size (needed for large mlmd file uploads)
                 
         # Serve the static health check page
         location = /check.html {


### PR DESCRIPTION
# Related Issues / Pull Requests

List all related issues and/or pull requests if there are any.

# Description

Include a brief summary of the proposed changes.

# What changes are proposed in this pull request?

- [ ]  Added client_max_body_size 0 to remove the default 1MB body size limit that caused 413 Request Entity Too Large errors when pushing large mlmd files to the server.

# Checklist:

- [ ] My code follows the style guidelines of this project (PEP-8 with Google-style docstrings).
- [ ] My code modifies existing public API, or introduces new public API, and I updated or wrote docstrings that
      uses Google-style formatting and any other formatting that is supported by mkdocs and plugins this project
      uses.
- [ ] I have commented my code.
- [ ] My code requires documentation updates, and I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.

<img width="1674" height="146" alt="Screenshot 2026-03-11 133723" src="https://github.com/user-attachments/assets/07a08457-d75c-41d7-8089-f0d271df8a79" />
