### PR TITLE
feat: Use fully qualified Docker image names for postgres and nginx

### DIFF
--- a/docker-compose-server.yml
+++ b/docker-compose-server.yml
@@ -16,7 +16,7 @@
 
 services:
   postgres:
-    image: postgres:13
+    image: docker.io/library/postgres:13
     container_name: postgres
     environment:
       POSTGRES_USER: ${POSTGRES_USER:-myuser}
@@ -131,7 +131,7 @@ services:
           - mcp
 
   nginx:
-    image: nginx:alpine
+    image: docker.io/library/nginx:alpine
     container_name: cmf-nginx
     ports:
       - ${NGINX_HTTP_PORT:-80}:80


### PR DESCRIPTION
Update postgres image from 'postgres:13' to 'docker.io/library/postgres:13' Update nginx image from 'nginx:alpine' to 'docker.io/library/nginx:alpine'

This ensures better compatibility with alternate container runtimes like podman compose often used in HPC environments.

# Related Issues / Pull Requests

This was breaking in HPC environments with podman compose. 

# Description

Include a brief summary of the proposed changes.

# What changes are proposed in this pull request?

- [X] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected; for instance, 
      examples in this repository need to be updated too).
- [ ] This change requires a documentation update.

# Checklist:

- [ ] My code follows the style guidelines of this project (PEP-8 with Google-style docstrings).
- [ ] My code modifies existing public API, or introduces new public API, and I updated or wrote docstrings that
      uses Google-style formatting and any other formatting that is supported by mkdocs and plugins this project
      uses.
- [ ] I have commented my code.
- [ ] My code requires documentation updates, and I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
