### PR TITLE
Feature/add skills

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -2,7 +2,7 @@
   "name": "cmf-plugins",
   "owner": {
     "name": "HewlettPackard",
-    "email": "cmf@hpe.com"
+    "email": "aalap.tripathy@hpe.com"
   },
   "metadata": {
     "description": "Agent skills for the Common Metadata Framework (CMF) — instrument ML pipelines, track artifacts, sync metadata, and query lineage",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,28 @@
+{
+  "name": "cmf-plugins",
+  "owner": {
+    "name": "HewlettPackard",
+    "email": "cmf@hpe.com"
+  },
+  "metadata": {
+    "description": "Agent skills for the Common Metadata Framework (CMF) — instrument ML pipelines, track artifacts, sync metadata, and query lineage",
+    "version": "1.0.0"
+  },
+  "plugins": [
+    {
+      "name": "cmf",
+      "source": "./",
+      "description": "Agent skills for CMF — instrument ML pipelines, track artifacts, sync metadata, and query lineage",
+      "version": "1.0.0",
+      "author": {
+        "name": "Hewlett Packard Enterprise",
+        "url": "https://hewlettpackard.github.io/cmf/"
+      },
+      "homepage": "https://hewlettpackard.github.io/cmf/",
+      "repository": "https://github.com/HewlettPackard/cmf",
+      "license": "Apache-2.0",
+      "keywords": ["cmf", "ml-pipeline", "metadata", "lineage", "mlops"],
+      "category": "ml-frameworks"
+    }
+  ]
+}

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,0 +1,13 @@
+{
+  "name": "cmf",
+  "description": "Agent skills for the Common Metadata Framework (CMF) — instrument ML pipelines, track artifacts, sync metadata, and query lineage",
+  "version": "1.0.0",
+  "author": {
+    "name": "Hewlett Packard Enterprise",
+    "url": "https://hewlettpackard.github.io/cmf/"
+  },
+  "homepage": "https://hewlettpackard.github.io/cmf/",
+  "repository": "https://github.com/HewlettPackard/cmf",
+  "license": "Apache-2.0",
+  "keywords": ["cmf", "ml-pipeline", "metadata", "lineage", "artifacts", "mlops", "dvc", "ml-metadata"]
+}

--- a/docs/skills/index.md
+++ b/docs/skills/index.md
@@ -21,7 +21,7 @@ This detects your coding agent and copies skills to the right directory automati
 To install a single skill:
 
 ```bash
-npx skills add HewlettPackard/cmf/tree/main/skills/cmf-instrument -y
+npx skills add HewlettPackard/cmf/tree/master/skills/cmf-instrument -y
 ```
 
 To install globally across all projects:

--- a/docs/skills/index.md
+++ b/docs/skills/index.md
@@ -81,6 +81,7 @@ Walks through installing `cmflib` and running `cmf init` with any supported stor
 - **Local** — single-machine development, artifacts in a local directory
 - **MinIO / Amazon S3** — shared object storage for teams
 - **SSH remote** — artifacts stored on a remote server
+- **OSDF** — distributed data federation across institutions (Pelican Platform)
 
 After this skill completes you will have a working configuration (`cmf init show` returns valid output) and be ready to instrument your pipeline.
 

--- a/docs/skills/index.md
+++ b/docs/skills/index.md
@@ -1,0 +1,198 @@
+# CMF Agent Skills
+
+CMF ships a set of **agent skills** that let AI coding assistants (Claude Code, GitHub Copilot in agent mode, Cursor, Gemini CLI, and others) guide users through every CMF workflow — from first-time setup to querying artifact lineage.
+
+Skills are prompt files that follow the [agentskills.io](https://agentskills.io) standard. Once installed, they appear as slash commands in your coding assistant's chat interface.
+
+---
+
+## Installing the skills
+
+### Automatic (recommended)
+
+From your ML project directory, run:
+
+```bash
+npx skills add HewlettPackard/cmf --full-depth -y
+```
+
+This detects your coding agent and copies skills to the right directory automatically. Works with Claude Code, GitHub Copilot, Cursor, Codex, OpenCode, and any [agentskills.io](https://agentskills.io)-compatible tool.
+
+To install a single skill:
+
+```bash
+npx skills add HewlettPackard/cmf/tree/main/skills/cmf-instrument -y
+```
+
+To install globally across all projects:
+
+```bash
+npx skills add HewlettPackard/cmf --full-depth -y --global
+```
+
+### Manual installation
+
+Copy each skill directory into your agent's skills folder:
+
+| Tool | Project-level directory | Global directory |
+|------|------------------------|-----------------|
+| Claude Code | `.claude/skills/<skill-name>/` | `~/.claude/skills/<skill-name>/` |
+| GitHub Copilot | `.agents/skills/<skill-name>/` | `~/.copilot/skills/<skill-name>/` |
+| Cursor | `.agents/skills/<skill-name>/` | `~/.cursor/skills/<skill-name>/` |
+| Codex | `.agents/skills/<skill-name>/` | `~/.codex/skills/<skill-name>/` |
+| OpenCode | `.agents/skills/<skill-name>/` | `~/.config/opencode/skills/<skill-name>/` |
+
+---
+
+## Available skills
+
+| Skill | Slash command | Purpose |
+|-------|--------------|---------|
+| **cmf** | `/cmf <task>` | Router — describe your task in plain language and get routed to the right skill |
+| **cmf-init** | `/cmf-init` | Install cmflib and run `cmf init` to configure a storage backend (local, S3, MinIO, SSH, OSDF) |
+| **cmf-instrument** | `/cmf-instrument` | Add CMF tracking to existing Python ML pipeline code |
+| **cmf-sync** | `/cmf-sync` | Push/pull metadata and artifacts to/from a CMF Server |
+| **cmf-query** | `/cmf-query` | Query pipeline history and artifact lineage with `CmfQuery` |
+| **cmf-server** | `/cmf-server` | Deploy CMF Server locally with Docker Compose, or connect to an existing server |
+| **cmf-mcp** | `/cmf-mcp` | Deploy the CMF MCP server for natural language metadata queries |
+
+---
+
+## Skill details
+
+### `/cmf` — Router skill
+
+The entry point for all CMF tasks. Describe what you want to do in plain language and the skill will route you to the correct specialized skill.
+
+**Usage examples:**
+
+```
+/cmf I want to start tracking metadata in my ML pipeline
+/cmf how do I push my artifacts to the CMF Server?
+/cmf show me the lineage for my trained model
+```
+
+---
+
+### `/cmf-init` — Initialize CMF
+
+Walks through installing `cmflib` and running `cmf init` with any supported storage backend:
+
+- **Local** — single-machine development, artifacts in a local directory
+- **MinIO / Amazon S3** — shared object storage for teams
+- **SSH remote** — artifacts stored on a remote server
+
+After this skill completes you will have a working configuration (`cmf init show` returns valid output) and be ready to instrument your pipeline.
+
+---
+
+### `/cmf-instrument` — Instrument ML code
+
+The core instrumentation skill. It adds CMF metadata tracking calls to your Python ML pipeline scripts:
+
+1. Imports `Cmf` and initializes the metadata writer
+2. Creates contexts (stage types) and executions (stage runs) with hyperparameters
+3. Logs datasets, models, and metrics as inputs and outputs
+4. Calls `finalize()` to record the Git commit SHA
+
+Includes copy-paste templates for data preparation, training, and evaluation stages, plus a checklist for auditing existing scripts.
+
+**Example instrumented training stage:**
+
+```python
+from cmflib.cmf import Cmf
+
+def train(train_path: str, model_path: str, params: dict) -> None:
+    metawriter = Cmf(filepath="mlmd", pipeline_name="my_pipeline")
+    metawriter.create_context(pipeline_stage="Train")
+    metawriter.create_execution(execution_type="Train", custom_properties=params)
+
+    metawriter.log_dataset(train_path, "input")
+
+    model = fit_model(train_path, params)
+
+    metawriter.log_model(path=model_path, event="output",
+                         model_framework="scikit-learn",
+                         model_type="RandomForestClassifier",
+                         model_name="RandomForestClassifier:default")
+    metawriter.finalize()
+```
+
+---
+
+### `/cmf-sync` — Sync metadata and artifacts
+
+Guides through the push/pull workflow for sharing results with teammates and a central CMF Server:
+
+```bash
+# Push your results
+cmf metadata push -p my_pipeline
+cmf artifact push -p my_pipeline
+
+# Pull a teammate's work
+cmf metadata pull -p my_pipeline
+cmf artifact pull -p my_pipeline
+```
+
+Covers solo and team workflows, error diagnosis, and the complete command reference.
+
+---
+
+### `/cmf-query` — Query lineage and artifacts
+
+Writes `CmfQuery` Python code for common metadata questions:
+
+- Listing pipelines and their stages
+- Comparing hyperparameters across training runs
+- Tracing a model's full data lineage
+- Finding all artifacts consumed or produced by an execution
+
+Also covers the CLI equivalents (`cmf pipeline list`, `cmf execution list`, `cmf artifact list`).
+
+---
+
+### `/cmf-server` — Deploy or connect to CMF Server
+
+Handles two scenarios:
+
+1. **Local deployment** — walks through cloning the CMF repo, creating a `.env` file with the right variables (`CMF_DATA_DIR`, `REACT_APP_CMF_API_URL`, `POSTGRES_*`, `MCP_EXTERNAL_PORT`), starting the Docker Compose stack, and verifying the web UI.
+
+2. **Existing server** — if a shared CMF Server is already running, guides the user through pointing their local `cmf init` at it with `--cmf-server-url`, verifying connectivity, and pushing the first pipeline.
+
+---
+
+### `/cmf-mcp` — CMF MCP server
+
+Covers two scenarios:
+
+1. **Setting up** — deploys the [CMF MCP Server](../mcp/index.md) with Docker and connects it to your AI assistant (Claude Code, GitHub Copilot, Cursor, Codex).
+2. **Already running** — if the CMF MCP server is already configured, shows how to use it from within your agent using natural language prompts like _"What pipelines are available?"_ or _"Show the artifact lineage for models/rf.pkl"_.
+
+After setup, the assistant calls CMF tools directly — no manual `CmfQuery` scripting required.
+
+---
+
+## Skill files
+
+The skill source files live in the `skills/` directory of the CMF repository:
+
+```
+skills/
+├── README.md               # Installation and usage instructions
+├── cmf/
+│   └── SKILL.md            # Router skill
+├── cmf-init/
+│   └── SKILL.md
+├── cmf-instrument/
+│   └── SKILL.md
+├── cmf-sync/
+│   └── SKILL.md
+├── cmf-query/
+│   └── SKILL.md
+├── cmf-server/
+│   └── SKILL.md
+└── cmf-mcp/
+    └── SKILL.md
+```
+
+See the [skills/README.md](https://github.com/HewlettPackard/cmf/blob/master/skills/README.md) for full details on installation, usage, and contributing new skills.

--- a/mkdocs.yaml
+++ b/mkdocs.yaml
@@ -159,3 +159,5 @@ nav:
       - Metahub: cmf_server/metahub-tab-usage.md
       - TensorBoard: cmf_client/tensorflow_guide.md
     - 🔗 Ontology: common-metadata-ontology/readme.md
+    - 🛠️ Agent Skills:
+      - skills/index.md

--- a/skills/README.md
+++ b/skills/README.md
@@ -1,0 +1,221 @@
+# CMF Skills
+
+Agent skills for the [Common Metadata Framework (CMF)](https://github.com/HewlettPackard/cmf) that help coding assistants instrument ML pipelines, query metadata, and manage artifacts.
+
+Compatible with Claude Code, GitHub Copilot (agent mode), Cursor, Gemini CLI, and any tool that supports the [agentskills.io](https://agentskills.io) standard.
+
+---
+
+## Installing the skills
+
+### Recommended — `npx skills add` (automatic, all agents)
+
+Run this command from your ML project directory:
+
+```bash
+npx skills add HewlettPackard/cmf --full-depth -y
+```
+
+This detects your coding agent and copies the skills to the correct directory automatically. Works with Claude Code, GitHub Copilot, Cursor, Codex, OpenCode, Gemini CLI, and any tool that supports the [agentskills.io](https://agentskills.io) standard.
+
+To install a single skill instead of the full set:
+
+```bash
+npx skills add HewlettPackard/cmf/tree/main/skills/cmf-instrument -y
+```
+
+To install globally (available in all projects):
+
+```bash
+npx skills add HewlettPackard/cmf --full-depth -y --global
+```
+
+### Manual installation (any agent)
+
+Clone or download this repository, then copy each skill directory you want into your agent's skills folder. The skill directory name must be preserved (e.g. `cmf-instrument/`).
+
+**Project-level** (skills available in this project only):
+
+| Tool | Skills directory |
+|------|-----------------|
+| Claude Code | `.claude/skills/<skill-name>/` |
+| GitHub Copilot | `.agents/skills/<skill-name>/` |
+| Cursor | `.agents/skills/<skill-name>/` |
+| Codex | `.agents/skills/<skill-name>/` |
+| OpenCode | `.agents/skills/<skill-name>/` |
+
+**Global** (skills available in all projects):
+
+| Tool | Skills directory |
+|------|-----------------|
+| Claude Code | `~/.claude/skills/<skill-name>/` |
+| GitHub Copilot | `~/.copilot/skills/<skill-name>/` |
+| Cursor | `~/.cursor/skills/<skill-name>/` |
+| Codex | `~/.codex/skills/<skill-name>/` |
+| OpenCode | `~/.config/opencode/skills/<skill-name>/` |
+
+**Example — install `cmf-instrument` globally for Claude Code:**
+
+```bash
+cp -r skills/cmf-instrument ~/.claude/skills/
+```
+
+**Example — install all CMF skills for GitHub Copilot (project-level):**
+
+```bash
+mkdir -p .agents/skills
+cp -r skills/cmf skills/cmf-init skills/cmf-instrument skills/cmf-sync skills/cmf-query skills/cmf-server skills/cmf-mcp .agents/skills/
+```
+
+### Claude Code marketplace
+
+```
+/plugin marketplace add HewlettPackard/cmf
+```
+
+---
+
+## Available skills
+
+| Skill | Invoke with | What it does |
+|-------|-------------|--------------|
+| **cmf** | `/cmf <task>` | Router — describes your task and gets routed to the right skill |
+| **cmf-init** | `/cmf-init` | Install cmflib, run `cmf init`, configure a storage backend (local, S3, MinIO, SSH, OSDF) |
+| **cmf-instrument** | `/cmf-instrument` | Add CMF tracking calls to existing Python ML pipeline code |
+| **cmf-sync** | `/cmf-sync` | Push/pull metadata and artifacts to/from a CMF Server |
+| **cmf-query** | `/cmf-query` | Query pipeline history and artifact lineage with `CmfQuery` |
+| **cmf-server** | `/cmf-server` | Deploy CMF Server locally with Docker Compose, or connect to an existing server |
+| **cmf-mcp** | `/cmf-mcp` | Deploy the CMF MCP server and connect it to your AI assistant |
+
+---
+
+## Using the skills
+
+After installation, activate a skill by typing its slash command in your coding assistant's chat:
+
+```
+/cmf I want to add metadata tracking to my training script
+```
+
+```
+/cmf-instrument
+```
+
+```
+/cmf-init
+```
+
+The **`/cmf`** router skill accepts a free-text description of your task and routes you to the right specialized skill automatically. Use the specific skill commands if you already know what you need.
+
+---
+
+## Skill descriptions
+
+### `/cmf` — Router
+
+Describe what you want to do with CMF in plain language. The skill identifies the right workflow and loads the appropriate sub-skill.
+
+**Examples:**
+- `/cmf I need to set up CMF for the first time`
+- `/cmf add metadata logging to my scikit-learn pipeline`
+- `/cmf how do I push my results to the CMF Server?`
+- `/cmf query the artifact lineage for my model`
+
+---
+
+### `/cmf-init` — Initialize CMF
+
+Guides you through installing `cmflib` and running `cmf init` with your chosen storage backend:
+
+- **Local** — artifacts stored on the local filesystem
+- **MinIO / Amazon S3** — object storage for teams
+- **SSH remote** — artifacts on a remote machine
+
+After this skill completes, you will have a working `cmf init show` output and be ready to instrument your pipeline.
+
+---
+
+### `/cmf-instrument` — Instrument ML code
+
+Adds CMF metadata tracking to your Python ML pipeline scripts. The skill will:
+
+1. Identify the stages in your code
+2. Add `Cmf()` initialization, `create_context()`, and `create_execution()` calls
+3. Log datasets, models, and metrics as inputs and outputs
+4. Add `finalize()` at the end of each stage
+
+Includes ready-to-use templates for data preparation, training, and evaluation stages, plus a checklist for auditing existing scripts.
+
+---
+
+### `/cmf-sync` — Sync metadata & artifacts
+
+Guides you through pushing your results to the CMF Server and pulling a teammate's work:
+
+```bash
+# Share your results
+cmf metadata push -p my_pipeline
+cmf artifact push -p my_pipeline
+
+# Get a teammate's results
+cmf metadata pull -p my_pipeline
+cmf artifact pull -p my_pipeline
+```
+
+Covers solo and collaborative team workflows, error handling, and the full push/pull command reference.
+
+---
+
+### `/cmf-query` — Query lineage & artifacts
+
+Writes `CmfQuery` Python code to answer questions about your pipeline:
+
+- List all pipelines and their stages
+- Compare hyperparameters across training runs
+- Trace a model's full data lineage (which datasets produced it?)
+- Find all artifacts consumed or produced by a specific execution
+- Export metadata for offline analysis
+
+Also covers the CLI equivalents (`cmf pipeline list`, `cmf execution list`, `cmf artifact list`).
+
+---
+
+### `/cmf-server` — Deploy or connect to CMF Server
+
+Two scenarios:
+
+1. **Local deployment** — clones the CMF repo, creates a `.env` file, and starts the full server stack with `docker compose -f docker-compose-server.yml up -d`. Stack includes PostgreSQL, CMF API server, React UI, TensorBoard, MCP server, and Nginx.
+
+2. **Connect to existing server** — if a CMF Server is already running (e.g. shared team server), configures the local `cmf init` to point at it with `--cmf-server-url`.
+
+Key `.env` variables covered: `CMF_DATA_DIR`, `NGINX_HTTP_PORT`, `REACT_APP_CMF_API_URL`, `POSTGRES_*`, `MCP_EXTERNAL_PORT`.
+
+---
+
+### `/cmf-mcp` — CMF MCP server
+
+Deploys the CMF MCP server with Docker and connects it to your AI assistant. After setup, your assistant can answer natural language questions like _"What pipelines are available?"_ or _"Show me the artifact lineage for the production model"_ by calling CMF tools directly.
+
+---
+
+## Updating the skills
+
+Run the same install command again to get the latest version:
+
+```bash
+npx skills add HewlettPackard/cmf --full-depth -y
+```
+
+---
+
+## Contributing
+
+Skills live in the `skills/` directory of this repository. Each skill is a folder containing a `SKILL.md` file with YAML frontmatter and instructional content.
+
+To add or improve a skill, edit the corresponding `SKILL.md` and open a pull request against the `master` branch.
+
+---
+
+## License
+
+Apache 2.0 — see [LICENSE](../LICENSE) for details.

--- a/skills/README.md
+++ b/skills/README.md
@@ -130,6 +130,7 @@ Guides you through installing `cmflib` and running `cmf init` with your chosen s
 - **Local** — artifacts stored on the local filesystem
 - **MinIO / Amazon S3** — object storage for teams
 - **SSH remote** — artifacts on a remote machine
+- **OSDF** — distributed data federation across institutions (Pelican Platform)
 
 After this skill completes, you will have a working `cmf init show` output and be ready to instrument your pipeline.
 

--- a/skills/README.md
+++ b/skills/README.md
@@ -21,7 +21,7 @@ This detects your coding agent and copies the skills to the correct directory au
 To install a single skill instead of the full set:
 
 ```bash
-npx skills add HewlettPackard/cmf/tree/main/skills/cmf-instrument -y
+npx skills add HewlettPackard/cmf/tree/master/skills/cmf-instrument -y
 ```
 
 To install globally (available in all projects):

--- a/skills/cmf-init/SKILL.md
+++ b/skills/cmf-init/SKILL.md
@@ -3,68 +3,40 @@ name: cmf-init
 description: >
   Use when setting up CMF in a new or existing project. Covers installing cmflib,
   running `cmf init` to configure a storage backend (local, S3, MinIO, SSH, or OSDF),
-  creating the mlmd metadata store, and verifying the setup. Works for both first-time
-  users and engineers setting up a new environment.
+  creating the mlmd metadata store, and verifying the setup.
 version: 1.0.0
 ---
 
-Initialize CMF in the user's project. Detect what they have, guide them through `cmf init`, and verify the setup ends with a working `mlmd` file.
-
-## Prerequisites
-
-- Python 3.9–3.11 (3.10 recommended)
-- Git repository initialized (`git init` if needed)
-- A storage backend available — see detection below
+Install cmflib, initialize a storage backend, and verify the setup. If CMF is already initialized, skip to [Verify initialization](#verify-initialization).
 
 ## Step 1 — Install cmflib
 
 ```bash
 pip install cmflib
-```
-
-Verify:
-
-```bash
-cmf --version
 python -c "from cmflib.cmf import Cmf; print('OK')"
 ```
 
-## Step 2 — Detect storage backend
+## Step 2 — Choose a storage backend
 
-Ask the user which backend they want, or detect from their environment:
-
-| Backend | When to use |
-|---------|------------|
-| `local` | Development on a single machine; artifacts stored in a local directory |
-| `minios3` | Team shares a MinIO server; S3-compatible object storage |
-| `amazons3` | Production; artifacts stored in AWS S3 |
-| `sshremote` | Artifacts stored on a remote machine over SSH |
-| `osdfremote` | Distributed research data federation (OSDF / Pelican Platform) across institutions |
+| Backend | Use when |
+|---------|---------|
+| `local` | Single-machine development |
+| `minios3` | Shared MinIO server (S3-compatible) |
+| `amazons3` | AWS S3 production storage |
+| `sshremote` | Artifacts on a remote machine over SSH |
+| `osdfremote` | OSDF distributed research data federation |
 
 ## Step 3 — Run `cmf init`
 
-### Local storage (quickstart)
-
+### Local
 ```bash
 cmf init local \
-  --path /path/to/local-artifact-storage \
+  --path /path/to/artifact-storage \
   --git-remote-url https://github.com/your-org/your-repo.git
 ```
+Optional: add `--cmf-server-url http://<server>:80` to point at a shared CMF Server.
 
-Optional: add CMF Server and Neo4j graph layer:
-
-```bash
-cmf init local \
-  --path /path/to/local-artifact-storage \
-  --git-remote-url https://github.com/your-org/your-repo.git \
-  --cmf-server-url http://<server-ip>:80 \
-  --neo4j-user neo4j \
-  --neo4j-password password \
-  --neo4j-uri bolt://localhost:7687
-```
-
-### MinIO / S3
-
+### MinIO / Amazon S3
 ```bash
 # MinIO
 cmf init minios3 \
@@ -83,20 +55,16 @@ cmf init amazons3 \
 ```
 
 ### SSH remote
-
 ```bash
 cmf init sshremote \
   --path ssh://user@host:/path/to/storage \
   --git-remote-url https://github.com/your-org/your-repo.git
 ```
 
-### OSDF remote (Open Science Data Federation)
+### OSDF remote
+Three authentication options — see [references/init-commands.md](references/init-commands.md#osdf-remote) for full parameter table.
 
-OSDF is a distributed data federation backed by the [Pelican Platform](https://pelicanplatform.org/), designed for sharing artifacts across institutions and national research compute pools.
-
-First confirm CMF is initialized (`cmf init show`), then choose one of three authentication options:
-
-**Option 1 — Pre-generated token (recommended):**
+**Option 1 — pre-generated token (recommended):**
 ```bash
 cmf init osdfremote \
   --path https://fdp-origin.labs.hpe.com:8443/fdp-hpe/cmf_test \
@@ -105,106 +73,21 @@ cmf init osdfremote \
   --git-remote-url https://github.com/your-org/your-repo.git
 ```
 
-**Option 2 — Key-based dynamic token generation:**
-```bash
-cmf init osdfremote \
-  --path https://fdp-origin.labs.hpe.com:8443/fdp-hpe/cmf_test \
-  --cache https://osdf-director.osg-htc.org/ \
-  --key-id XXXX \
-  --key-path ~/private_hpe.pem \
-  --key-issuer https://t.nationalresearchplatform.org/fdp-hpe \
-  --git-remote-url https://github.com/your-org/your-repo.git
-```
-
-**Option 3 — Default token location** (token stored at `~/.fdp/osdf_token`, no explicit flag needed):
-```bash
-cmf init osdfremote \
-  --path https://fdp-origin.labs.hpe.com:8443/fdp-hpe/cmf_test \
-  --cache https://osdf-director.osg-htc.org/ \
-  --git-remote-url https://github.com/your-org/your-repo.git
-```
-
-**OSDF parameters:**
-
-| Parameter | Required | Purpose |
-|-----------|----------|---------|
-| `--path` | Yes | OSDF origin server URL (writes go here) |
-| `--git-remote-url` | Yes | Git repository URL for version control |
-| `--cache` | No | OSDF cache/director URL — improves read performance |
-| `--access-token` | No* | Pre-generated token file path or plain text |
-| `--key-id` | No* | Key identifier for dynamic token generation |
-| `--key-path` | No* | Private key file for dynamic token generation |
-| `--key-issuer` | No* | Token issuer URL for dynamic token generation |
-
-\* Provide either `--access-token` OR all three `--key-*` parameters, or place the token at `~/.fdp/osdf_token`.
-
-CMF validates the token automatically before push/pull and displays its issuer, scope, and expiry.
-
-## Step 4 — Verify initialization
+## Verify initialization
 
 ```bash
-cmf init show
+cmf init show   # should display remote, git URL, and optional server URL
 ```
 
-Expected output shows the configured DVC remote, Git remote URL, and (optionally) CMF Server URL.
-
-## Step 5 — Confirm the mlmd file is created
-
-The `mlmd` file appears after the first pipeline run. It is created automatically when your instrumented code first calls `Cmf(filepath="mlmd", ...)`. It does **not** exist after `cmf init` alone.
-
-## Quick reference card
-
-| Command | Purpose |
-|---------|---------|
-| `cmf init local --path <dir> --git-remote-url <url>` | Init with local storage |
-| `cmf init minios3 ...` | Init with MinIO / S3 backend |
-| `cmf init amazons3 ...` | Init with Amazon S3 |
-| `cmf init sshremote --path ssh://user@host:/path ...` | Init with SSH remote |
-| `cmf init osdfremote --path <origin-url> ...` | Init with OSDF storage |
-| `cmf init show` | Show current configuration |
-| `cmf init --help` | All init options |
-
-## Guided walkthrough (new users)
-
-1. Create a working directory and initialize Git:
-   ```bash
-   mkdir my-ml-project && cd my-ml-project
-   git init
-   git remote add origin https://github.com/your-org/your-repo.git
-   ```
-
-2. Install CMF:
-   ```bash
-   pip install cmflib
-   ```
-
-3. Create a local artifact directory (outside the repo is fine):
-   ```bash
-   mkdir -p ~/cmf-artifacts
-   ```
-
-4. Initialize CMF:
-   ```bash
-   cmf init local --path ~/cmf-artifacts --git-remote-url https://github.com/your-org/your-repo.git
-   ```
-
-5. Confirm with `cmf init show` — you should see the DVC remote and Git URL.
-
-6. Now instrument your pipeline code. See the **cmf-instrument** skill.
+The `mlmd` file is created automatically on the first pipeline run, not by `cmf init` itself.
 
 ## Troubleshooting
 
-- **`cmf: command not found`** — run `pip install cmflib` and ensure your Python `bin` directory is on `PATH`
-- **`git remote` error** — `cmf init` requires a configured Git remote; add one with `git remote add origin <url>`
-- **DVC errors** — CMF uses DVC internally; if DVC is not installed, `pip install cmflib` should include it; check with `dvc --version`
-- **MinIO connection refused** — verify the MinIO server is running and the `--url` matches the server address and port
-- **OSDF token expired or invalid** — CMF validates the token on init; regenerate the token or use key-based auth. Check expiry with `cmf init show`
-- **OSDF push fails with permission error** — the token may lack write scope for the configured `--path`. Contact your OSDF origin administrator
+- **`cmf: command not found`** — run `pip install cmflib`; ensure Python `bin/` is on `PATH`
+- **Git remote error** — add a remote first: `git remote add origin <url>`
+- **OSDF token expired** — regenerate token or switch to key-based auth
+- **MinIO connection refused** — verify the MinIO server is up and `--url` matches
 
-## Further reading
+---
 
-- `docs/cmf_client/index.md` — Full CMF Client CLI guide
-- `docs/cmf_client/local-storage-setup.md` — Local storage details
-- `docs/cmf_client/minio-server.md` — MinIO backend setup
-- `docs/cmf_client/ssh-setup.md` — SSH remote setup
-- `docs/cmf_client/cmf_osdf.md` — OSDF remote setup and token authentication
+**Docs:** [Getting Started](https://hewlettpackard.github.io/cmf/) · [Storage Backends](https://hewlettpackard.github.io/cmf/cmf_client/) · [OSDF Setup](https://hewlettpackard.github.io/cmf/cmf_client/cmf_osdf/) · [Full Tutorial](https://hewlettpackard.github.io/cmf/examples/getting_started/)

--- a/skills/cmf-init/SKILL.md
+++ b/skills/cmf-init/SKILL.md
@@ -1,0 +1,210 @@
+---
+name: cmf-init
+description: >
+  Use when setting up CMF in a new or existing project. Covers installing cmflib,
+  running `cmf init` to configure a storage backend (local, S3, MinIO, or SSH),
+  creating the mlmd metadata store, and verifying the setup. Works for both first-time
+  users and engineers setting up a new environment.
+version: 1.0.0
+---
+
+Initialize CMF in the user's project. Detect what they have, guide them through `cmf init`, and verify the setup ends with a working `mlmd` file.
+
+## Prerequisites
+
+- Python 3.9–3.11 (3.10 recommended)
+- Git repository initialized (`git init` if needed)
+- A storage backend available — see detection below
+
+## Step 1 — Install cmflib
+
+```bash
+pip install cmflib
+```
+
+Verify:
+
+```bash
+cmf --version
+python -c "from cmflib.cmf import Cmf; print('OK')"
+```
+
+## Step 2 — Detect storage backend
+
+Ask the user which backend they want, or detect from their environment:
+
+| Backend | When to use |
+|---------|------------|
+| `local` | Development on a single machine; artifacts stored in a local directory |
+| `minios3` | Team shares a MinIO server; S3-compatible object storage |
+| `amazons3` | Production; artifacts stored in AWS S3 |
+| `sshremote` | Artifacts stored on a remote machine over SSH |
+| `osdfremote` | Distributed research data federation (OSDF / Pelican Platform) across institutions |
+
+## Step 3 — Run `cmf init`
+
+### Local storage (quickstart)
+
+```bash
+cmf init local \
+  --path /path/to/local-artifact-storage \
+  --git-remote-url https://github.com/your-org/your-repo.git
+```
+
+Optional: add CMF Server and Neo4j graph layer:
+
+```bash
+cmf init local \
+  --path /path/to/local-artifact-storage \
+  --git-remote-url https://github.com/your-org/your-repo.git \
+  --cmf-server-url http://<server-ip>:80 \
+  --neo4j-user neo4j \
+  --neo4j-password password \
+  --neo4j-uri bolt://localhost:7687
+```
+
+### MinIO / S3
+
+```bash
+# MinIO
+cmf init minios3 \
+  --url http://<minio-host>:9000 \
+  --endpoint-url http://<minio-host>:9000 \
+  --access-key-id <key> \
+  --secret-access-key <secret> \
+  --git-remote-url https://github.com/your-org/your-repo.git
+
+# Amazon S3
+cmf init amazons3 \
+  --url s3://your-bucket/path \
+  --access-key-id <key> \
+  --secret-access-key <secret> \
+  --git-remote-url https://github.com/your-org/your-repo.git
+```
+
+### SSH remote
+
+```bash
+cmf init sshremote \
+  --path ssh://user@host:/path/to/storage \
+  --git-remote-url https://github.com/your-org/your-repo.git
+```
+
+### OSDF remote (Open Science Data Federation)
+
+OSDF is a distributed data federation backed by the [Pelican Platform](https://pelicanplatform.org/), designed for sharing artifacts across institutions and national research compute pools.
+
+First confirm CMF is initialized (`cmf init show`), then choose one of three authentication options:
+
+**Option 1 — Pre-generated token (recommended):**
+```bash
+cmf init osdfremote \
+  --path https://fdp-origin.labs.hpe.com:8443/fdp-hpe/cmf_test \
+  --cache https://osdf-director.osg-htc.org/ \
+  --access-token ~/.fdp/osdf_token \
+  --git-remote-url https://github.com/your-org/your-repo.git
+```
+
+**Option 2 — Key-based dynamic token generation:**
+```bash
+cmf init osdfremote \
+  --path https://fdp-origin.labs.hpe.com:8443/fdp-hpe/cmf_test \
+  --cache https://osdf-director.osg-htc.org/ \
+  --key-id XXXX \
+  --key-path ~/private_hpe.pem \
+  --key-issuer https://t.nationalresearchplatform.org/fdp-hpe \
+  --git-remote-url https://github.com/your-org/your-repo.git
+```
+
+**Option 3 — Default token location** (token stored at `~/.fdp/osdf_token`, no explicit flag needed):
+```bash
+cmf init osdfremote \
+  --path https://fdp-origin.labs.hpe.com:8443/fdp-hpe/cmf_test \
+  --cache https://osdf-director.osg-htc.org/ \
+  --git-remote-url https://github.com/your-org/your-repo.git
+```
+
+**OSDF parameters:**
+
+| Parameter | Required | Purpose |
+|-----------|----------|---------|
+| `--path` | Yes | OSDF origin server URL (writes go here) |
+| `--git-remote-url` | Yes | Git repository URL for version control |
+| `--cache` | No | OSDF cache/director URL — improves read performance |
+| `--access-token` | No* | Pre-generated token file path or plain text |
+| `--key-id` | No* | Key identifier for dynamic token generation |
+| `--key-path` | No* | Private key file for dynamic token generation |
+| `--key-issuer` | No* | Token issuer URL for dynamic token generation |
+
+\* Provide either `--access-token` OR all three `--key-*` parameters, or place the token at `~/.fdp/osdf_token`.
+
+CMF validates the token automatically before push/pull and displays its issuer, scope, and expiry.
+
+## Step 4 — Verify initialization
+
+```bash
+cmf init show
+```
+
+Expected output shows the configured DVC remote, Git remote URL, and (optionally) CMF Server URL.
+
+## Step 5 — Confirm the mlmd file is created
+
+The `mlmd` file appears after the first pipeline run. It is created automatically when your instrumented code first calls `Cmf(filepath="mlmd", ...)`. It does **not** exist after `cmf init` alone.
+
+## Quick reference card
+
+| Command | Purpose |
+|---------|---------|
+| `cmf init local --path <dir> --git-remote-url <url>` | Init with local storage |
+| `cmf init minios3 ...` | Init with MinIO / S3 backend |
+| `cmf init amazons3 ...` | Init with Amazon S3 |
+| `cmf init sshremote --path ssh://user@host:/path ...` | Init with SSH remote |
+| `cmf init osdfremote --path <origin-url> ...` | Init with OSDF storage |
+| `cmf init show` | Show current configuration |
+| `cmf init --help` | All init options |
+
+## Guided walkthrough (new users)
+
+1. Create a working directory and initialize Git:
+   ```bash
+   mkdir my-ml-project && cd my-ml-project
+   git init
+   git remote add origin https://github.com/your-org/your-repo.git
+   ```
+
+2. Install CMF:
+   ```bash
+   pip install cmflib
+   ```
+
+3. Create a local artifact directory (outside the repo is fine):
+   ```bash
+   mkdir -p ~/cmf-artifacts
+   ```
+
+4. Initialize CMF:
+   ```bash
+   cmf init local --path ~/cmf-artifacts --git-remote-url https://github.com/your-org/your-repo.git
+   ```
+
+5. Confirm with `cmf init show` — you should see the DVC remote and Git URL.
+
+6. Now instrument your pipeline code. See the **cmf-instrument** skill.
+
+## Troubleshooting
+
+- **`cmf: command not found`** — run `pip install cmflib` and ensure your Python `bin` directory is on `PATH`
+- **`git remote` error** — `cmf init` requires a configured Git remote; add one with `git remote add origin <url>`
+- **DVC errors** — CMF uses DVC internally; if DVC is not installed, `pip install cmflib` should include it; check with `dvc --version`
+- **MinIO connection refused** — verify the MinIO server is running and the `--url` matches the server address and port
+- **OSDF token expired or invalid** — CMF validates the token on init; regenerate the token or use key-based auth. Check expiry with `cmf init show`
+- **OSDF push fails with permission error** — the token may lack write scope for the configured `--path`. Contact your OSDF origin administrator
+
+## Further reading
+
+- `docs/cmf_client/index.md` — Full CMF Client CLI guide
+- `docs/cmf_client/local-storage-setup.md` — Local storage details
+- `docs/cmf_client/minio-server.md` — MinIO backend setup
+- `docs/cmf_client/ssh-setup.md` — SSH remote setup
+- `docs/cmf_client/cmf_osdf.md` — OSDF remote setup and token authentication

--- a/skills/cmf-init/SKILL.md
+++ b/skills/cmf-init/SKILL.md
@@ -83,10 +83,12 @@ The `mlmd` file is created automatically on the first pipeline run, not by `cmf 
 
 ## Troubleshooting
 
-- **`cmf: command not found`** — run `pip install cmflib`; ensure Python `bin/` is on `PATH`
-- **Git remote error** — add a remote first: `git remote add origin <url>`
-- **OSDF token expired** — regenerate token or switch to key-based auth
-- **MinIO connection refused** — verify the MinIO server is up and `--url` matches
+- **`cmf: command not found`** — run `pip install cmflib`; ensure Python `bin/` is on `PATH`; verify with `cmf --version`
+- **Git remote error** — CMF requires a configured Git remote; run `git remote add origin <url>` first
+- **DVC errors** — CMF uses DVC internally; verify with `dvc --version`; reinstall with `pip install cmflib`
+- **MinIO connection refused** — verify the MinIO server is up and `--url` matches the server address and port
+- **OSDF token expired or invalid** — CMF validates the token on init and shows issuer, scope, and expiry; regenerate or switch to key-based auth
+- **OSDF push fails with permission error** — token may lack write scope for `--path`; contact your OSDF origin administrator
 
 ---
 

--- a/skills/cmf-init/SKILL.md
+++ b/skills/cmf-init/SKILL.md
@@ -1,22 +1,128 @@
 ---
 name: cmf-init
 description: >
-  Use when setting up CMF in a new or existing project. Covers installing cmflib,
-  running `cmf init` to configure a storage backend (local, S3, MinIO, SSH, or OSDF),
-  creating the mlmd metadata store, and verifying the setup.
+  Use when setting up CMF in a new or existing project. Covers creating a Python
+  environment (conda, uv, or venv), installing cmflib (requires Python 3.9–3.11,
+  recommended 3.10), running `cmf init` to configure a storage backend (local, S3,
+  MinIO, SSH, or OSDF), and verifying the setup.
 version: 1.0.0
 ---
 
-Install cmflib, initialize a storage backend, and verify the setup. If CMF is already initialized, skip to [Verify initialization](#verify-initialization).
+Install cmflib into a Python environment, initialize a storage backend, and verify the setup. If CMF is already initialized, skip to [Verify initialization](#verify-initialization).
 
-## Step 1 — Install cmflib
+## Step 1 — Set up a Python environment
+
+CMF requires **Python 3.9–3.11** (3.10 recommended). Choose the tool you have:
+
+### uv (fastest — install if not present)
+```bash
+# Install uv if needed
+curl -LsSf https://astral.sh/uv/install.sh | sh
+
+uv venv .cmf --python 3.10
+source .cmf/bin/activate        # Windows: .cmf\Scripts\activate
+```
+
+### conda
+```bash
+conda create -n cmf python=3.10
+conda activate cmf
+```
+If conda is not installed, use uv or venv instead.
+
+### venv (built-in — always available)
+```bash
+python3.10 -m venv .cmf
+source .cmf/bin/activate        # Windows: .cmf\Scripts\activate
+```
+If `python3.10` is not found, use `python3 -m venv .cmf` and verify the version with `python --version`.
+
+## Step 2 — Install cmflib
 
 ```bash
 pip install cmflib
 python -c "from cmflib.cmf import Cmf; print('OK')"
 ```
 
-## Step 2 — Choose a storage backend
+## Step 3 — Choose a storage backend
+
+| Backend | Use when |
+|---------|---------|
+| `local` | Single-machine development |
+| `minios3` | Shared MinIO server (S3-compatible) |
+| `amazons3` | AWS S3 production storage |
+| `sshremote` | Artifacts on a remote machine over SSH |
+| `osdfremote` | OSDF distributed research data federation |
+
+## Step 4 — Run `cmf init`
+
+### Local
+```bash
+cmf init local \
+  --path /path/to/artifact-storage \
+  --git-remote-url https://github.com/your-org/your-repo.git
+```
+Optional: add `--cmf-server-url http://<server>:80` to point at a shared CMF Server.
+
+### MinIO / Amazon S3
+```bash
+# MinIO
+cmf init minios3 \
+  --url http://<minio-host>:9000 \
+  --endpoint-url http://<minio-host>:9000 \
+  --access-key-id <key> \
+  --secret-access-key <secret> \
+  --git-remote-url https://github.com/your-org/your-repo.git
+
+# Amazon S3
+cmf init amazons3 \
+  --url s3://your-bucket/path \
+  --access-key-id <key> \
+  --secret-access-key <secret> \
+  --git-remote-url https://github.com/your-org/your-repo.git
+```
+
+### SSH remote
+```bash
+cmf init sshremote \
+  --path ssh://user@host:/path/to/storage \
+  --git-remote-url https://github.com/your-org/your-repo.git
+```
+
+### OSDF remote
+Three authentication options — see [references/init-commands.md](references/init-commands.md#osdf-remote) for full parameter table.
+
+**Option 1 — pre-generated token (recommended):**
+```bash
+cmf init osdfremote \
+  --path https://fdp-origin.labs.hpe.com:8443/fdp-hpe/cmf_test \
+  --cache https://osdf-director.osg-htc.org/ \
+  --access-token ~/.fdp/osdf_token \
+  --git-remote-url https://github.com/your-org/your-repo.git
+```
+
+## Verify initialization
+
+```bash
+cmf init show   # should display remote, git URL, and optional server URL
+```
+
+The `mlmd` file is created automatically on the first pipeline run, not by `cmf init` itself.
+
+## Troubleshooting
+
+- **`cmf: command not found`** — ensure the virtual environment is activated; verify with `cmf --version`
+- **Wrong Python version** — check with `python --version`; create a new env targeting 3.10 (`uv venv .cmf --python 3.10` or `conda create -n cmf python=3.10`)
+- **`python3.10` not found (venv)** — install via system package manager (`sudo apt install python3.10`) or use uv/conda which manage Python versions automatically
+- **Git remote error** — CMF requires a configured Git remote; run `git remote add origin <url>` first
+- **DVC errors** — CMF uses DVC internally; verify with `dvc --version`; reinstall with `pip install cmflib`
+- **MinIO connection refused** — verify the MinIO server is up and `--url` matches the server address and port
+- **OSDF token expired or invalid** — CMF validates the token on init and shows issuer, scope, and expiry; regenerate or switch to key-based auth
+- **OSDF push fails with permission error** — token may lack write scope for `--path`; contact your OSDF origin administrator
+
+---
+
+**Docs:** [Getting Started](https://hewlettpackard.github.io/cmf/) · [Storage Backends](https://hewlettpackard.github.io/cmf/cmf_client/) · [OSDF Setup](https://hewlettpackard.github.io/cmf/cmf_client/cmf_osdf/) · [Full Tutorial](https://hewlettpackard.github.io/cmf/examples/getting_started/)
 
 | Backend | Use when |
 |---------|---------|

--- a/skills/cmf-init/SKILL.md
+++ b/skills/cmf-init/SKILL.md
@@ -2,7 +2,7 @@
 name: cmf-init
 description: >
   Use when setting up CMF in a new or existing project. Covers installing cmflib,
-  running `cmf init` to configure a storage backend (local, S3, MinIO, or SSH),
+  running `cmf init` to configure a storage backend (local, S3, MinIO, SSH, or OSDF),
   creating the mlmd metadata store, and verifying the setup. Works for both first-time
   users and engineers setting up a new environment.
 version: 1.0.0

--- a/skills/cmf-init/SKILL.md
+++ b/skills/cmf-init/SKILL.md
@@ -4,38 +4,27 @@ description: >
   Use when setting up CMF in a new or existing project. Covers creating a Python
   environment (conda, uv, or venv), installing cmflib (requires Python 3.9–3.11,
   recommended 3.10), running `cmf init` to configure a storage backend (local, S3,
-  MinIO, SSH, or OSDF), and verifying the setup.
+  MinIO, SSH, or OSDF), and verifying the setup. Linux only — cmflib does not support macOS.
 version: 1.0.0
 ---
+
+> **macOS is not supported.** cmflib does not install or run on macOS. See open issues
+> [#185](https://github.com/HewlettPackard/cmf/issues/185) and
+> [#263](https://github.com/HewlettPackard/cmf/issues/263) for status.
+> Use a Linux machine or a Linux VM/container instead.
 
 Install cmflib into a Python environment, initialize a storage backend, and verify the setup. If CMF is already initialized, skip to [Verify initialization](#verify-initialization).
 
 ## Step 1 — Set up a Python environment
 
-CMF requires **Python 3.9–3.11** (3.10 recommended). Choose the tool you have:
+CMF requires **Python 3.9–3.11** (3.10 recommended). Use whichever tool is available:
 
-### uv (fastest — install if not present)
-```bash
-# Install uv if needed
-curl -LsSf https://astral.sh/uv/install.sh | sh
+- **conda** (if installed) — `conda create -n cmf python=3.10 && conda activate cmf`
+- **venv** (built-in) — `python3.10 -m venv .cmf && source .cmf/bin/activate`
+- **uv** (fastest, auto-installs Python) — `uv venv .cmf --python 3.10 && source .cmf/bin/activate`
+- **none of the above** — skip environment creation and run `pip install cmflib` directly into your system Python (3.9–3.11 only)
 
-uv venv .cmf --python 3.10
-source .cmf/bin/activate        # Windows: .cmf\Scripts\activate
-```
-
-### conda
-```bash
-conda create -n cmf python=3.10
-conda activate cmf
-```
-If conda is not installed, use uv or venv instead.
-
-### venv (built-in — always available)
-```bash
-python3.10 -m venv .cmf
-source .cmf/bin/activate        # Windows: .cmf\Scripts\activate
-```
-If `python3.10` is not found, use `python3 -m venv .cmf` and verify the version with `python --version`.
+See [references/init-commands.md](references/init-commands.md#environment-setup--detailed-options) for full install commands, OS-specific instructions, and a guided walkthrough.
 
 ## Step 2 — Install cmflib
 
@@ -90,7 +79,7 @@ cmf init sshremote \
 ```
 
 ### OSDF remote
-Three authentication options — see [references/init-commands.md](references/init-commands.md#osdf-remote) for full parameter table.
+Three authentication options — see [references/init-commands.md](references/init-commands.md#osdf-remote-osdfremote) for full parameter table.
 
 **Option 1 — pre-generated token (recommended):**
 ```bash
@@ -111,85 +100,10 @@ The `mlmd` file is created automatically on the first pipeline run, not by `cmf 
 
 ## Troubleshooting
 
+- **macOS** — cmflib is not supported; use Linux or a Linux container
 - **`cmf: command not found`** — ensure the virtual environment is activated; verify with `cmf --version`
 - **Wrong Python version** — check with `python --version`; create a new env targeting 3.10 (`uv venv .cmf --python 3.10` or `conda create -n cmf python=3.10`)
 - **`python3.10` not found (venv)** — install via system package manager (`sudo apt install python3.10`) or use uv/conda which manage Python versions automatically
-- **Git remote error** — CMF requires a configured Git remote; run `git remote add origin <url>` first
-- **DVC errors** — CMF uses DVC internally; verify with `dvc --version`; reinstall with `pip install cmflib`
-- **MinIO connection refused** — verify the MinIO server is up and `--url` matches the server address and port
-- **OSDF token expired or invalid** — CMF validates the token on init and shows issuer, scope, and expiry; regenerate or switch to key-based auth
-- **OSDF push fails with permission error** — token may lack write scope for `--path`; contact your OSDF origin administrator
-
----
-
-**Docs:** [Getting Started](https://hewlettpackard.github.io/cmf/) · [Storage Backends](https://hewlettpackard.github.io/cmf/cmf_client/) · [OSDF Setup](https://hewlettpackard.github.io/cmf/cmf_client/cmf_osdf/) · [Full Tutorial](https://hewlettpackard.github.io/cmf/examples/getting_started/)
-
-| Backend | Use when |
-|---------|---------|
-| `local` | Single-machine development |
-| `minios3` | Shared MinIO server (S3-compatible) |
-| `amazons3` | AWS S3 production storage |
-| `sshremote` | Artifacts on a remote machine over SSH |
-| `osdfremote` | OSDF distributed research data federation |
-
-## Step 3 — Run `cmf init`
-
-### Local
-```bash
-cmf init local \
-  --path /path/to/artifact-storage \
-  --git-remote-url https://github.com/your-org/your-repo.git
-```
-Optional: add `--cmf-server-url http://<server>:80` to point at a shared CMF Server.
-
-### MinIO / Amazon S3
-```bash
-# MinIO
-cmf init minios3 \
-  --url http://<minio-host>:9000 \
-  --endpoint-url http://<minio-host>:9000 \
-  --access-key-id <key> \
-  --secret-access-key <secret> \
-  --git-remote-url https://github.com/your-org/your-repo.git
-
-# Amazon S3
-cmf init amazons3 \
-  --url s3://your-bucket/path \
-  --access-key-id <key> \
-  --secret-access-key <secret> \
-  --git-remote-url https://github.com/your-org/your-repo.git
-```
-
-### SSH remote
-```bash
-cmf init sshremote \
-  --path ssh://user@host:/path/to/storage \
-  --git-remote-url https://github.com/your-org/your-repo.git
-```
-
-### OSDF remote
-Three authentication options — see [references/init-commands.md](references/init-commands.md#osdf-remote) for full parameter table.
-
-**Option 1 — pre-generated token (recommended):**
-```bash
-cmf init osdfremote \
-  --path https://fdp-origin.labs.hpe.com:8443/fdp-hpe/cmf_test \
-  --cache https://osdf-director.osg-htc.org/ \
-  --access-token ~/.fdp/osdf_token \
-  --git-remote-url https://github.com/your-org/your-repo.git
-```
-
-## Verify initialization
-
-```bash
-cmf init show   # should display remote, git URL, and optional server URL
-```
-
-The `mlmd` file is created automatically on the first pipeline run, not by `cmf init` itself.
-
-## Troubleshooting
-
-- **`cmf: command not found`** — run `pip install cmflib`; ensure Python `bin/` is on `PATH`; verify with `cmf --version`
 - **Git remote error** — CMF requires a configured Git remote; run `git remote add origin <url>` first
 - **DVC errors** — CMF uses DVC internally; verify with `dvc --version`; reinstall with `pip install cmflib`
 - **MinIO connection refused** — verify the MinIO server is up and `--url` matches the server address and port

--- a/skills/cmf-init/SKILL.md
+++ b/skills/cmf-init/SKILL.md
@@ -17,14 +17,31 @@ Install cmflib into a Python environment, initialize a storage backend, and veri
 
 ## Step 1 — Set up a Python environment
 
-CMF requires **Python 3.9–3.11** (3.10 recommended). Use whichever tool is available:
+CMF requires **Python 3.9–3.11** (3.10 recommended).
 
-- **conda** (if installed) — `conda create -n cmf python=3.10 && conda activate cmf`
-- **venv** (built-in) — `python3.10 -m venv .cmf && source .cmf/bin/activate`
-- **uv** (fastest, auto-installs Python) — `uv venv .cmf --python 3.10 && source .cmf/bin/activate`
-- **none of the above** — skip environment creation and run `pip install cmflib` directly into your system Python (3.9–3.11 only)
+Detect available tools and ask the user which they prefer:
 
-See [references/init-commands.md](references/init-commands.md#environment-setup--detailed-options) for full install commands, OS-specific instructions, and a guided walkthrough.
+```bash
+which uv && echo "uv available" || echo "uv not found"
+which conda && echo "conda available" || echo "conda not found"
+# venv is always available via Python's standard library
+```
+
+| Tool | Priority | Command |
+|------|----------|---------|
+| **uv** | Preferred — offer to install if missing | `uv venv .cmf --python 3.10 && source .cmf/bin/activate` |
+| **conda** | Next — use if uv unavailable | `conda create -n cmf python=3.10 && conda activate cmf` |
+| **venv** | Always available fallback | `python3.10 -m venv .cmf && source .cmf/bin/activate` |
+
+If **uv is not installed**, offer to install it (manages Python versions automatically):
+```bash
+curl -LsSf https://astral.sh/uv/install.sh | sh   # Linux
+# or: pip install uv
+```
+
+If **none of the above** apply, skip environment creation and install directly with `pip install cmflib` (requires system Python 3.9–3.11).
+
+See [references/init-commands.md](references/init-commands.md#environment-setup--detailed-options) for full OS-specific setup and a guided walkthrough.
 
 ## Step 2 — Install cmflib
 

--- a/skills/cmf-init/references/init-commands.md
+++ b/skills/cmf-init/references/init-commands.md
@@ -87,3 +87,42 @@ cmf init osdfremote \
 ```bash
 cmf init show
 ```
+
+## Guided walkthrough (new projects)
+
+Full end-to-end setup from scratch with local storage:
+
+```bash
+# 1. Create a working directory and initialize Git
+mkdir my-ml-project && cd my-ml-project
+git init
+git remote add origin https://github.com/your-org/your-repo.git
+
+# 2. Install CMF
+pip install cmflib
+
+# 3. Create a local artifact directory (outside the repo is fine)
+mkdir -p ~/cmf-artifacts
+
+# 4. Initialize CMF
+cmf init local \
+  --path ~/cmf-artifacts \
+  --git-remote-url https://github.com/your-org/your-repo.git
+
+# 5. Confirm
+cmf init show
+```
+
+The `mlmd` file appears only after the first instrumented pipeline run — not after `cmf init`.
+
+## Python 3.9 on Ubuntu — known issue
+
+If you encounter `ModuleNotFoundError: No module named 'distutils.cmd'`:
+
+```bash
+sudo add-apt-repository ppa:deadsnakes/ppa
+sudo apt-get update
+sudo apt install python3.9 python3.9-dev python3.9-distutils python3.9-venv
+```
+
+Python 3.10 is recommended to avoid this.

--- a/skills/cmf-init/references/init-commands.md
+++ b/skills/cmf-init/references/init-commands.md
@@ -88,9 +88,77 @@ cmf init osdfremote \
 cmf init show
 ```
 
+## Python version compatibility
+
+| Python | Status |
+|--------|--------|
+| 3.10 | **Recommended** |
+| 3.11 | Supported |
+| 3.9 | Supported (see Ubuntu note below) |
+| ≤ 3.8 or ≥ 3.12 | Not supported |
+
+## Environment setup — detailed options
+
+### uv (recommended for speed)
+
+```bash
+# Install uv (once per machine)
+curl -LsSf https://astral.sh/uv/install.sh | sh   # macOS / Linux
+# or: pip install uv
+
+# Create environment with exact Python version
+uv venv .cmf --python 3.10
+
+# Activate
+source .cmf/bin/activate          # macOS / Linux
+.cmf\Scripts\activate             # Windows
+
+# Install CMF
+pip install cmflib
+```
+
+uv downloads the requested Python version automatically if it is not installed locally — no separate Python installation needed.
+
+### conda
+
+```bash
+conda create -n cmf python=3.10
+conda activate cmf
+pip install cmflib
+```
+
+If conda is not installed, download [Miniconda](https://docs.conda.io/en/latest/miniconda.html) (minimal) or [Anaconda](https://www.anaconda.com/download) (full). Alternatively use uv or venv.
+
+### venv (built-in, no extras needed)
+
+```bash
+# Linux / macOS — use the specific Python binary
+python3.10 -m venv .cmf
+source .cmf/bin/activate
+
+# Windows
+py -3.10 -m venv .cmf
+.cmf\Scripts\activate
+
+pip install cmflib
+```
+
+If `python3.10` is not available, install it via your system package manager:
+```bash
+# Ubuntu / Debian
+sudo apt install python3.10 python3.10-venv
+
+# macOS (Homebrew)
+brew install python@3.10
+
+# Windows — download from python.org
+```
+
+Or switch to uv/conda, which manage Python versions for you.
+
 ## Guided walkthrough (new projects)
 
-Full end-to-end setup from scratch with local storage:
+Full end-to-end setup from scratch with local storage, using uv:
 
 ```bash
 # 1. Create a working directory and initialize Git
@@ -98,18 +166,22 @@ mkdir my-ml-project && cd my-ml-project
 git init
 git remote add origin https://github.com/your-org/your-repo.git
 
-# 2. Install CMF
+# 2. Set up Python environment
+uv venv .cmf --python 3.10
+source .cmf/bin/activate    # Windows: .cmf\Scripts\activate
+
+# 3. Install CMF
 pip install cmflib
 
-# 3. Create a local artifact directory (outside the repo is fine)
+# 4. Create a local artifact directory (outside the repo is fine)
 mkdir -p ~/cmf-artifacts
 
-# 4. Initialize CMF
+# 5. Initialize CMF
 cmf init local \
   --path ~/cmf-artifacts \
   --git-remote-url https://github.com/your-org/your-repo.git
 
-# 5. Confirm
+# 6. Confirm
 cmf init show
 ```
 
@@ -125,4 +197,4 @@ sudo apt-get update
 sudo apt install python3.9 python3.9-dev python3.9-distutils python3.9-venv
 ```
 
-Python 3.10 is recommended to avoid this.
+Use Python 3.10 to avoid this entirely.

--- a/skills/cmf-init/references/init-commands.md
+++ b/skills/cmf-init/references/init-commands.md
@@ -9,7 +9,7 @@ cmf init local \
   [--neo4j-user <user> --neo4j-password <pw> --neo4j-uri bolt://localhost:7687]
 ```
 
-## MinIO (minios3)
+## MinIO (minios3) · [Docs](https://hewlettpackard.github.io/cmf/cmf_client/minio-server/)
 ```bash
 cmf init minios3 \
   --url http://<host>:9000 \
@@ -30,7 +30,7 @@ cmf init amazons3 \
   [--cmf-server-url <url>]
 ```
 
-## SSH remote (sshremote)
+## SSH remote (sshremote) · [Docs](https://hewlettpackard.github.io/cmf/cmf_client/ssh-setup/)
 ```bash
 cmf init sshremote \
   --path ssh://user@host:/path/to/storage \
@@ -38,7 +38,7 @@ cmf init sshremote \
   [--cmf-server-url <url>]
 ```
 
-## OSDF remote (osdfremote)
+## OSDF remote (osdfremote) · [Docs](https://hewlettpackard.github.io/cmf/cmf_client/cmf_osdf/)
 
 ### Option 1 — Pre-generated token
 ```bash
@@ -97,7 +97,7 @@ cmf init show
 | 3.9 | Supported (see Ubuntu note below) |
 | ≤ 3.8 or ≥ 3.12 | Not supported |
 
-## Environment setup — detailed options
+## Environment setup — detailed options · [Docs](https://hewlettpackard.github.io/cmf/setup/#install-cmf-library-ie-cmflib)
 
 ### uv (recommended for speed)
 
@@ -198,3 +198,10 @@ sudo apt install python3.9 python3.9-dev python3.9-distutils python3.9-venv
 ```
 
 Use Python 3.10 to avoid this entirely.
+
+## References
+
+- [Installing cmflib](https://hewlettpackard.github.io/cmf/setup/#install-cmf-library-ie-cmflib)
+- [MinIO server setup](https://hewlettpackard.github.io/cmf/cmf_client/minio-server/)
+- [SSH remote setup](https://hewlettpackard.github.io/cmf/cmf_client/ssh-setup/)
+- [OSDF remote setup](https://hewlettpackard.github.io/cmf/cmf_client/cmf_osdf/)

--- a/skills/cmf-init/references/init-commands.md
+++ b/skills/cmf-init/references/init-commands.md
@@ -1,0 +1,89 @@
+# CMF Init Command Reference
+
+## Local storage
+```bash
+cmf init local \
+  --path <dir> \
+  --git-remote-url <url> \
+  [--cmf-server-url <url>] \
+  [--neo4j-user <user> --neo4j-password <pw> --neo4j-uri bolt://localhost:7687]
+```
+
+## MinIO (minios3)
+```bash
+cmf init minios3 \
+  --url http://<host>:9000 \
+  --endpoint-url http://<host>:9000 \
+  --access-key-id <key> \
+  --secret-access-key <secret> \
+  --git-remote-url <url> \
+  [--cmf-server-url <url>]
+```
+
+## Amazon S3 (amazons3)
+```bash
+cmf init amazons3 \
+  --url s3://<bucket>/<path> \
+  --access-key-id <key> \
+  --secret-access-key <secret> \
+  --git-remote-url <url> \
+  [--cmf-server-url <url>]
+```
+
+## SSH remote (sshremote)
+```bash
+cmf init sshremote \
+  --path ssh://user@host:/path/to/storage \
+  --git-remote-url <url> \
+  [--cmf-server-url <url>]
+```
+
+## OSDF remote (osdfremote)
+
+### Option 1 — Pre-generated token
+```bash
+cmf init osdfremote \
+  --path <origin-url> \
+  --cache <cache-url> \
+  --access-token <token-file-or-string> \
+  --git-remote-url <url>
+```
+
+### Option 2 — Key-based dynamic token
+```bash
+cmf init osdfremote \
+  --path <origin-url> \
+  --cache <cache-url> \
+  --key-id <id> \
+  --key-path <pem-file> \
+  --key-issuer <issuer-url> \
+  --git-remote-url <url>
+```
+
+### Option 3 — Default token location
+Place token at `~/.fdp/osdf_token`, then:
+```bash
+cmf init osdfremote \
+  --path <origin-url> \
+  --cache <cache-url> \
+  --git-remote-url <url>
+```
+
+### OSDF parameters
+
+| Parameter | Required | Purpose |
+|-----------|----------|---------|
+| `--path` | Yes | OSDF origin server URL (writes go here) |
+| `--git-remote-url` | Yes | Git repository URL |
+| `--cache` | No | OSDF cache/director URL — improves read performance |
+| `--access-token` | No* | Pre-generated token file path or value |
+| `--key-id` | No* | Key identifier for dynamic token generation |
+| `--key-path` | No* | Private key file for dynamic token generation |
+| `--key-issuer` | No* | Token issuer URL |
+
+\* Provide `--access-token` OR all three `--key-*` params, or place token at `~/.fdp/osdf_token`.
+
+## Verify
+```bash
+cmf init show
+```

--- a/skills/cmf-init/sources.md
+++ b/skills/cmf-init/sources.md
@@ -1,0 +1,10 @@
+# Sources
+
+References used for this skill's content.
+
+- [CMF Client Quick Start](https://hewlettpackard.github.io/cmf/cmf_client/)
+- [Local Storage Setup](https://hewlettpackard.github.io/cmf/cmf_client/local-storage-setup/)
+- [MinIO Backend Setup](https://hewlettpackard.github.io/cmf/cmf_client/minio-server/)
+- [SSH Remote Setup](https://hewlettpackard.github.io/cmf/cmf_client/ssh-setup/)
+- [OSDF Remote Setup](https://hewlettpackard.github.io/cmf/cmf_client/cmf_osdf/)
+- [Installation Guide](https://hewlettpackard.github.io/cmf/setup/)

--- a/skills/cmf-instrument/SKILL.md
+++ b/skills/cmf-instrument/SKILL.md
@@ -2,182 +2,102 @@
 name: cmf-instrument
 description: >
   Use when adding CMF metadata tracking to existing Python ML pipeline code, or writing
-  new CMF-instrumented pipeline stages from scratch. Covers importing cmflib, initializing
-  Cmf(), creating contexts and executions, logging datasets, models, metrics, and calling
-  finalize(). Includes ready-to-use code templates for common ML pipeline patterns.
+  new CMF-instrumented pipeline stages from scratch. Covers the Cmf() API: create_context,
+  create_execution, log_dataset, log_model, log_metric, commit_metrics, log_execution_metrics,
+  and finalize(). Includes copy-paste templates for common ML pipeline stages.
 version: 1.0.0
 ---
 
-Instrument the user's Python ML code with CMF metadata tracking. Identify the pipeline stages in their code and add the correct CMF calls to each one.
+Add CMF tracking to the user's Python pipeline. Identify each stage and apply the five-step pattern below.
 
-## How CMF instrumentation works
-
-Every pipeline stage follows the same four-step pattern:
-
-```
-1. Cmf(...)              → connect to the metadata store
-2. create_context(...)   → declare the stage type
-3. create_execution(...) → start this particular run (log hyperparameters here)
-4. log_dataset / log_model / log_metric  → log inputs and outputs
-5. finalize()            → commit code version and close the execution
-```
-
-## Step 1 — Import and initialize
+## The five-step pattern (every stage)
 
 ```python
 from cmflib.cmf import Cmf
 
-metawriter = Cmf(
-    filepath="mlmd",                  # local SQLite metadata store
-    pipeline_name="my_pipeline",      # must be the same across all stages
-    graph=False                       # set True if Neo4j graph layer is configured
+metawriter = Cmf(filepath="mlmd", pipeline_name="my_pipeline")  # 1. connect
+metawriter.create_context(pipeline_stage="Train")               # 2. stage type
+metawriter.create_execution(                                     # 3. this run
+    execution_type="Train",
+    custom_properties={"learning_rate": 0.01, "seed": 42}       #    ← hyperparameters go here
 )
-```
-
-- Use the **same `pipeline_name`** in every stage of the pipeline.
-- `filepath` is relative to the project root; `"mlmd"` is the conventional name.
-- Add `graph=True` only after running `cmf init` with `--neo4j-*` flags.
-
-## Step 2 — Create context (stage type)
-
-```python
-context = metawriter.create_context(
-    pipeline_stage="Train",           # stage name — use the same name every run
-    custom_properties={               # optional stage-level metadata
-        "framework": "scikit-learn",
-        "task": "classification"
-    }
-)
-```
-
-Contexts group all executions of the same stage. The `pipeline_stage` name should be consistent across runs (e.g., always `"Train"`, not `"train_v2"`, `"Train_new"`, etc.).
-
-## Step 3 — Create execution (one run)
-
-```python
-execution = metawriter.create_execution(
-    execution_type="Train",           # usually matches pipeline_stage
-    custom_properties={               # hyperparameters and run-specific settings
-        "learning_rate": 0.01,
-        "n_estimators": 100,
-        "seed": 42
-    }
-)
-```
-
-Hyperparameters, random seeds, and any run-specific parameters go in `custom_properties`. CMF guarantees unique execution names automatically.
-
-## Step 4 — Log artifacts
-
-### Datasets
-
-```python
-# Input dataset
-metawriter.log_dataset(
-    "data/train.csv",                 # path relative to project root
-    "input",                          # "input" or "output"
-    custom_properties={"split": "train", "rows": 10000}
-)
-
-# Output dataset
-metawriter.log_dataset(
-    "data/processed/train.pkl",
-    "output",
-    custom_properties={"format": "pickle"}
-)
-```
-
-To log a dataset with its labels file:
-
-```python
-metawriter.log_dataset(
-    "data/raw.csv",
-    "input",
-    label="data/labels.csv",
-    label_properties={"annotator": "team-a"}
-)
-```
-
-### Models
-
-```python
-# Saving a model (output)
-metawriter.log_model(
-    path="models/rf.pkl",
-    event="output",
+metawriter.log_dataset("data/train.csv", "input")               # 4. log artifacts
+metawriter.log_model("models/rf.pkl", event="output",           #
     model_framework="scikit-learn",
     model_type="RandomForestClassifier",
     model_name="RandomForestClassifier:v1"
 )
-
-# Loading a model (input)
-metawriter.log_model(
-    path="models/rf.pkl",
-    event="input"
-)
+metawriter.finalize()                                            # 5. record git SHA
 ```
 
-### Per-step metrics (training loop)
+Rules:
+- Use the **same `pipeline_name`** in every stage of the pipeline
+- Keep `pipeline_stage` name stable across runs (don't add version suffixes)
+- All artifact paths must be **relative to the project root**
+- Call `finalize()` once per stage script
+
+## Logging datasets
 
 ```python
+metawriter.log_dataset("data/raw.csv", "input")
+metawriter.log_dataset("data/processed/train.pkl", "output",
+    custom_properties={"format": "pickle", "rows": 10000})
+
+# With labels file
+metawriter.log_dataset("data/raw.csv", "input",
+    label="data/labels.csv", label_properties={"annotator": "team-a"})
+```
+
+## Logging models
+
+```python
+# Output (saving)
+metawriter.log_model("models/rf.pkl", event="output",
+    model_framework="scikit-learn",
+    model_type="RandomForestClassifier",
+    model_name="RandomForestClassifier:v1")
+
+# Input (loading)
+metawriter.log_model("models/rf.pkl", event="input")
+```
+
+## Logging metrics
+
+```python
+# Per-step metrics (inside training loop)
 for epoch in range(num_epochs):
-    loss = train_one_epoch(...)
-    metawriter.log_metric("training_metrics", {"loss": loss, "epoch": epoch})
+    metawriter.log_metric("train_metrics", {"loss": loss, "epoch": epoch})
+metawriter.commit_metrics("train_metrics")   # ← must call to persist
 
-metawriter.commit_metrics("training_metrics")  # write the parquet file and commit
+# Final stage metrics
+metawriter.log_execution_metrics("eval_metrics",
+    {"accuracy": 0.94, "roc_auc": 0.97})
 ```
 
-### Final / stage metrics
+## Stage templates
 
+### Data preparation
 ```python
-metawriter.log_execution_metrics(
-    "eval_metrics",
-    {"accuracy": 0.94, "roc_auc": 0.97, "avg_precision": 0.91}
-)
-```
-
-## Step 5 — Finalize
-
-```python
-metawriter.finalize()   # commits code version to Git; call once per stage script
-```
-
-Always call `finalize()` at the end of each stage script. It records the Git commit SHA and closes the execution.
-
-## Full stage templates
-
-### Data preparation stage
-
-```python
-from cmflib.cmf import Cmf
-
-def prepare(input_path: str, output_dir: str, params: dict) -> None:
+def prepare(input_path, output_dir, params):
     metawriter = Cmf(filepath="mlmd", pipeline_name="my_pipeline")
     metawriter.create_context(pipeline_stage="Prepare")
     metawriter.create_execution(execution_type="Prepare", custom_properties=params)
 
     metawriter.log_dataset(input_path, "input")
-
-    # ... your data processing logic here ...
-
+    # ... your processing logic ...
     metawriter.log_dataset(f"{output_dir}/train.pkl", "output")
     metawriter.log_dataset(f"{output_dir}/test.pkl", "output")
     metawriter.finalize()
 ```
 
-### Training stage
-
+### Training
 ```python
-from cmflib.cmf import Cmf
-
-def train(train_path: str, model_path: str, params: dict) -> None:
+def train(train_path, model_path, params):
     metawriter = Cmf(filepath="mlmd", pipeline_name="my_pipeline")
     metawriter.create_context(pipeline_stage="Train")
     metawriter.create_execution(execution_type="Train", custom_properties=params)
 
     metawriter.log_dataset(train_path, "input")
-
-    # ... your training logic here ...
     model = fit_model(train_path, params)
 
     for i, loss in enumerate(training_losses):
@@ -185,91 +105,40 @@ def train(train_path: str, model_path: str, params: dict) -> None:
     metawriter.commit_metrics("train_metrics")
 
     save_model(model, model_path)
-    metawriter.log_model(
-        path=model_path,
-        event="output",
+    metawriter.log_model(model_path, event="output",
         model_framework="scikit-learn",
         model_type="RandomForestClassifier",
-        model_name="RandomForestClassifier:default"
-    )
+        model_name="RandomForestClassifier:default")
     metawriter.finalize()
 ```
 
-### Evaluation stage
-
+### Evaluation
 ```python
-from cmflib.cmf import Cmf
-
-def evaluate(model_path: str, test_path: str, params: dict) -> None:
+def evaluate(model_path, test_path, params):
     metawriter = Cmf(filepath="mlmd", pipeline_name="my_pipeline")
     metawriter.create_context(pipeline_stage="Evaluate")
     metawriter.create_execution(execution_type="Evaluate", custom_properties=params)
 
-    metawriter.log_model(path=model_path, event="input")
+    metawriter.log_model(model_path, event="input")
     metawriter.log_dataset(test_path, "input")
-
-    # ... your evaluation logic here ...
     accuracy, roc_auc = run_evaluation(model_path, test_path)
-
-    metawriter.log_execution_metrics("eval_metrics", {
-        "accuracy": accuracy,
-        "roc_auc": roc_auc
-    })
+    metawriter.log_execution_metrics("eval_metrics",
+        {"accuracy": accuracy, "roc_auc": roc_auc})
     metawriter.finalize()
 ```
 
-## Checklist for instrumenting an existing file
+## Instrumentation checklist
 
-When adding CMF to an existing pipeline script, work through this checklist:
+- [ ] `from cmflib.cmf import Cmf` added at top
+- [ ] `Cmf(filepath="mlmd", pipeline_name="<pipeline>")` — same name every stage
+- [ ] `create_context(pipeline_stage="<StageName>")` — stable name
+- [ ] `create_execution(...)` — hyperparameters in `custom_properties`
+- [ ] Every significant input logged with `"input"`, every output with `"output"`
+- [ ] `commit_metrics()` called after every `log_metric()` loop
+- [ ] `finalize()` at the end
 
-- [ ] Add `from cmflib.cmf import Cmf` at the top
-- [ ] Create `metawriter = Cmf(filepath="mlmd", pipeline_name="<pipeline>")` before any logging
-- [ ] Call `create_context(pipeline_stage="<StageName>")` — same name every run
-- [ ] Call `create_execution(execution_type="<type>", custom_properties=<params_dict>)` — put hyperparameters here
-- [ ] Log every significant input file with `log_dataset(..., "input")`
-- [ ] Log every significant output file with `log_dataset(..., "output")` or `log_model(..., event="output")`
-- [ ] Log per-step metrics inside the training loop, then call `commit_metrics()`
-- [ ] Log final stage metrics with `log_execution_metrics()`
-- [ ] Call `finalize()` at the end of the stage
+See [references/api-reference.md](references/api-reference.md) for the full method signature table and data slice API.
 
-## Data slice tracking (bias analysis)
+---
 
-```python
-import random
-
-dataslice = metawriter.create_dataslice("validation-slice-female")
-for sample_id in random.sample(female_sample_ids, 200):
-    dataslice.add_data(f"data/raw/{sample_id}.json")
-dataslice.commit()
-```
-
-Use data slices to track subsets of data for fairness and bias analysis.
-
-## Quick reference
-
-| Method | Signature | Purpose |
-|--------|-----------|---------|
-| `Cmf()` | `Cmf(filepath, pipeline_name, graph=False)` | Connect to metadata store |
-| `create_context()` | `create_context(pipeline_stage, custom_properties={})` | Declare stage type |
-| `create_execution()` | `create_execution(execution_type, custom_properties={}, cmd="")` | Start a run |
-| `log_dataset()` | `log_dataset(url, event, custom_properties={}, label=None)` | Log dataset artifact |
-| `log_model()` | `log_model(path, event, model_framework="", model_type="", model_name="")` | Log model artifact |
-| `log_metric()` | `log_metric(metrics_name, custom_properties)` | Log per-step metric |
-| `commit_metrics()` | `commit_metrics(metrics_name)` | Finalize step metrics |
-| `log_execution_metrics()` | `log_execution_metrics(metrics_name, custom_properties)` | Log final stage metrics |
-| `create_dataslice()` | `create_dataslice(name)` | Create a data subset tracker |
-| `finalize()` | `finalize()` | Commit code version and close execution |
-
-## Common mistakes
-
-- **Wrong `pipeline_name`** across stages: stages won't be grouped into the same pipeline. Use the exact same string.
-- **Calling `create_context` with a different name each run**: this creates a new stage type every run. Keep the `pipeline_stage` name stable.
-- **Logging absolute paths**: use paths relative to the project root so CMF can identify the same artifact across environments.
-- **Forgetting `finalize()`**: the Git commit SHA won't be recorded, breaking reproducibility tracking.
-- **Logging metrics without `commit_metrics()`**: step metrics are buffered; they won't be persisted without a commit call.
-
-## Further reading
-
-- `docs/cmflib/index.md` — Full API reference with diagrams
-- `examples/example-get-started/src/` — Complete 4-stage pipeline example (parse, featurize, train, test)
-- `docs/examples/getting_started.md` — Getting started tutorial
+**Docs:** [cmflib API](https://hewlettpackard.github.io/cmf/cmflib/) · [Cmf class reference](https://hewlettpackard.github.io/cmf/api/public/cmf/) · [Getting Started tutorial](https://hewlettpackard.github.io/cmf/examples/getting_started/)

--- a/skills/cmf-instrument/SKILL.md
+++ b/skills/cmf-instrument/SKILL.md
@@ -1,0 +1,275 @@
+---
+name: cmf-instrument
+description: >
+  Use when adding CMF metadata tracking to existing Python ML pipeline code, or writing
+  new CMF-instrumented pipeline stages from scratch. Covers importing cmflib, initializing
+  Cmf(), creating contexts and executions, logging datasets, models, metrics, and calling
+  finalize(). Includes ready-to-use code templates for common ML pipeline patterns.
+version: 1.0.0
+---
+
+Instrument the user's Python ML code with CMF metadata tracking. Identify the pipeline stages in their code and add the correct CMF calls to each one.
+
+## How CMF instrumentation works
+
+Every pipeline stage follows the same four-step pattern:
+
+```
+1. Cmf(...)              → connect to the metadata store
+2. create_context(...)   → declare the stage type
+3. create_execution(...) → start this particular run (log hyperparameters here)
+4. log_dataset / log_model / log_metric  → log inputs and outputs
+5. finalize()            → commit code version and close the execution
+```
+
+## Step 1 — Import and initialize
+
+```python
+from cmflib.cmf import Cmf
+
+metawriter = Cmf(
+    filepath="mlmd",                  # local SQLite metadata store
+    pipeline_name="my_pipeline",      # must be the same across all stages
+    graph=False                       # set True if Neo4j graph layer is configured
+)
+```
+
+- Use the **same `pipeline_name`** in every stage of the pipeline.
+- `filepath` is relative to the project root; `"mlmd"` is the conventional name.
+- Add `graph=True` only after running `cmf init` with `--neo4j-*` flags.
+
+## Step 2 — Create context (stage type)
+
+```python
+context = metawriter.create_context(
+    pipeline_stage="Train",           # stage name — use the same name every run
+    custom_properties={               # optional stage-level metadata
+        "framework": "scikit-learn",
+        "task": "classification"
+    }
+)
+```
+
+Contexts group all executions of the same stage. The `pipeline_stage` name should be consistent across runs (e.g., always `"Train"`, not `"train_v2"`, `"Train_new"`, etc.).
+
+## Step 3 — Create execution (one run)
+
+```python
+execution = metawriter.create_execution(
+    execution_type="Train",           # usually matches pipeline_stage
+    custom_properties={               # hyperparameters and run-specific settings
+        "learning_rate": 0.01,
+        "n_estimators": 100,
+        "seed": 42
+    }
+)
+```
+
+Hyperparameters, random seeds, and any run-specific parameters go in `custom_properties`. CMF guarantees unique execution names automatically.
+
+## Step 4 — Log artifacts
+
+### Datasets
+
+```python
+# Input dataset
+metawriter.log_dataset(
+    "data/train.csv",                 # path relative to project root
+    "input",                          # "input" or "output"
+    custom_properties={"split": "train", "rows": 10000}
+)
+
+# Output dataset
+metawriter.log_dataset(
+    "data/processed/train.pkl",
+    "output",
+    custom_properties={"format": "pickle"}
+)
+```
+
+To log a dataset with its labels file:
+
+```python
+metawriter.log_dataset(
+    "data/raw.csv",
+    "input",
+    label="data/labels.csv",
+    label_properties={"annotator": "team-a"}
+)
+```
+
+### Models
+
+```python
+# Saving a model (output)
+metawriter.log_model(
+    path="models/rf.pkl",
+    event="output",
+    model_framework="scikit-learn",
+    model_type="RandomForestClassifier",
+    model_name="RandomForestClassifier:v1"
+)
+
+# Loading a model (input)
+metawriter.log_model(
+    path="models/rf.pkl",
+    event="input"
+)
+```
+
+### Per-step metrics (training loop)
+
+```python
+for epoch in range(num_epochs):
+    loss = train_one_epoch(...)
+    metawriter.log_metric("training_metrics", {"loss": loss, "epoch": epoch})
+
+metawriter.commit_metrics("training_metrics")  # write the parquet file and commit
+```
+
+### Final / stage metrics
+
+```python
+metawriter.log_execution_metrics(
+    "eval_metrics",
+    {"accuracy": 0.94, "roc_auc": 0.97, "avg_precision": 0.91}
+)
+```
+
+## Step 5 — Finalize
+
+```python
+metawriter.finalize()   # commits code version to Git; call once per stage script
+```
+
+Always call `finalize()` at the end of each stage script. It records the Git commit SHA and closes the execution.
+
+## Full stage templates
+
+### Data preparation stage
+
+```python
+from cmflib.cmf import Cmf
+
+def prepare(input_path: str, output_dir: str, params: dict) -> None:
+    metawriter = Cmf(filepath="mlmd", pipeline_name="my_pipeline")
+    metawriter.create_context(pipeline_stage="Prepare")
+    metawriter.create_execution(execution_type="Prepare", custom_properties=params)
+
+    metawriter.log_dataset(input_path, "input")
+
+    # ... your data processing logic here ...
+
+    metawriter.log_dataset(f"{output_dir}/train.pkl", "output")
+    metawriter.log_dataset(f"{output_dir}/test.pkl", "output")
+    metawriter.finalize()
+```
+
+### Training stage
+
+```python
+from cmflib.cmf import Cmf
+
+def train(train_path: str, model_path: str, params: dict) -> None:
+    metawriter = Cmf(filepath="mlmd", pipeline_name="my_pipeline")
+    metawriter.create_context(pipeline_stage="Train")
+    metawriter.create_execution(execution_type="Train", custom_properties=params)
+
+    metawriter.log_dataset(train_path, "input")
+
+    # ... your training logic here ...
+    model = fit_model(train_path, params)
+
+    for i, loss in enumerate(training_losses):
+        metawriter.log_metric("train_metrics", {"loss": loss, "step": i})
+    metawriter.commit_metrics("train_metrics")
+
+    save_model(model, model_path)
+    metawriter.log_model(
+        path=model_path,
+        event="output",
+        model_framework="scikit-learn",
+        model_type="RandomForestClassifier",
+        model_name="RandomForestClassifier:default"
+    )
+    metawriter.finalize()
+```
+
+### Evaluation stage
+
+```python
+from cmflib.cmf import Cmf
+
+def evaluate(model_path: str, test_path: str, params: dict) -> None:
+    metawriter = Cmf(filepath="mlmd", pipeline_name="my_pipeline")
+    metawriter.create_context(pipeline_stage="Evaluate")
+    metawriter.create_execution(execution_type="Evaluate", custom_properties=params)
+
+    metawriter.log_model(path=model_path, event="input")
+    metawriter.log_dataset(test_path, "input")
+
+    # ... your evaluation logic here ...
+    accuracy, roc_auc = run_evaluation(model_path, test_path)
+
+    metawriter.log_execution_metrics("eval_metrics", {
+        "accuracy": accuracy,
+        "roc_auc": roc_auc
+    })
+    metawriter.finalize()
+```
+
+## Checklist for instrumenting an existing file
+
+When adding CMF to an existing pipeline script, work through this checklist:
+
+- [ ] Add `from cmflib.cmf import Cmf` at the top
+- [ ] Create `metawriter = Cmf(filepath="mlmd", pipeline_name="<pipeline>")` before any logging
+- [ ] Call `create_context(pipeline_stage="<StageName>")` — same name every run
+- [ ] Call `create_execution(execution_type="<type>", custom_properties=<params_dict>)` — put hyperparameters here
+- [ ] Log every significant input file with `log_dataset(..., "input")`
+- [ ] Log every significant output file with `log_dataset(..., "output")` or `log_model(..., event="output")`
+- [ ] Log per-step metrics inside the training loop, then call `commit_metrics()`
+- [ ] Log final stage metrics with `log_execution_metrics()`
+- [ ] Call `finalize()` at the end of the stage
+
+## Data slice tracking (bias analysis)
+
+```python
+import random
+
+dataslice = metawriter.create_dataslice("validation-slice-female")
+for sample_id in random.sample(female_sample_ids, 200):
+    dataslice.add_data(f"data/raw/{sample_id}.json")
+dataslice.commit()
+```
+
+Use data slices to track subsets of data for fairness and bias analysis.
+
+## Quick reference
+
+| Method | Signature | Purpose |
+|--------|-----------|---------|
+| `Cmf()` | `Cmf(filepath, pipeline_name, graph=False)` | Connect to metadata store |
+| `create_context()` | `create_context(pipeline_stage, custom_properties={})` | Declare stage type |
+| `create_execution()` | `create_execution(execution_type, custom_properties={}, cmd="")` | Start a run |
+| `log_dataset()` | `log_dataset(url, event, custom_properties={}, label=None)` | Log dataset artifact |
+| `log_model()` | `log_model(path, event, model_framework="", model_type="", model_name="")` | Log model artifact |
+| `log_metric()` | `log_metric(metrics_name, custom_properties)` | Log per-step metric |
+| `commit_metrics()` | `commit_metrics(metrics_name)` | Finalize step metrics |
+| `log_execution_metrics()` | `log_execution_metrics(metrics_name, custom_properties)` | Log final stage metrics |
+| `create_dataslice()` | `create_dataslice(name)` | Create a data subset tracker |
+| `finalize()` | `finalize()` | Commit code version and close execution |
+
+## Common mistakes
+
+- **Wrong `pipeline_name`** across stages: stages won't be grouped into the same pipeline. Use the exact same string.
+- **Calling `create_context` with a different name each run**: this creates a new stage type every run. Keep the `pipeline_stage` name stable.
+- **Logging absolute paths**: use paths relative to the project root so CMF can identify the same artifact across environments.
+- **Forgetting `finalize()`**: the Git commit SHA won't be recorded, breaking reproducibility tracking.
+- **Logging metrics without `commit_metrics()`**: step metrics are buffered; they won't be persisted without a commit call.
+
+## Further reading
+
+- `docs/cmflib/index.md` — Full API reference with diagrams
+- `examples/example-get-started/src/` — Complete 4-stage pipeline example (parse, featurize, train, test)
+- `docs/examples/getting_started.md` — Getting started tutorial

--- a/skills/cmf-instrument/references/api-reference.md
+++ b/skills/cmf-instrument/references/api-reference.md
@@ -1,0 +1,53 @@
+# cmflib API Reference
+
+## Cmf class
+
+```python
+from cmflib.cmf import Cmf
+
+metawriter = Cmf(
+    filepath="mlmd",           # path to SQLite metadata store (relative to project root)
+    pipeline_name="name",      # pipeline identifier — same across all stages
+    custom_properties={},      # optional pipeline-level properties
+    graph=False                # set True to enable Neo4j graph layer
+)
+```
+
+## Method reference
+
+| Method | Signature | Purpose |
+|--------|-----------|---------|
+| `create_context` | `(pipeline_stage, custom_properties={})` | Declare a stage type |
+| `create_execution` | `(execution_type, custom_properties={}, cmd="")` | Start a run; log hyperparameters |
+| `log_dataset` | `(url, event, custom_properties={}, label=None, label_properties={})` | Log dataset artifact |
+| `log_model` | `(path, event, model_framework="", model_type="", model_name="")` | Log model artifact |
+| `log_metric` | `(metrics_name, custom_properties)` | Log one step's metrics (buffered) |
+| `commit_metrics` | `(metrics_name)` | Flush buffered metrics to parquet file |
+| `log_execution_metrics` | `(metrics_name, custom_properties)` | Log final stage-level metrics |
+| `create_dataslice` | `(name)` → `DataSlice` | Create a data subset tracker |
+| `finalize` | `()` | Record Git SHA and close execution |
+
+### `log_dataset` parameters
+- `url` — artifact path relative to project root
+- `event` — `"input"` or `"output"`
+- `custom_properties` — dict of arbitrary metadata (e.g. `{"split": "train", "rows": 5000}`)
+- `label` — path to labels file (optional)
+- `label_properties` — metadata for the labels file (optional)
+
+### `log_model` parameters
+- `path` — model file path relative to project root
+- `event` — `"input"` or `"output"`
+- `model_framework` — e.g. `"scikit-learn"`, `"pytorch"`, `"tensorflow"`
+- `model_type` — e.g. `"RandomForestClassifier"`, `"ResNet50"`
+- `model_name` — human-readable identifier, e.g. `"RandomForestClassifier:v1"`
+
+## DataSlice API
+
+```python
+dataslice = metawriter.create_dataslice("validation-slice-female")
+for sample_id in sample_ids:
+    dataslice.add_data(f"data/raw/{sample_id}.json")
+dataslice.commit()
+```
+
+Use data slices to track subsets of data for fairness and bias analysis across model versions.

--- a/skills/cmf-instrument/sources.md
+++ b/skills/cmf-instrument/sources.md
@@ -1,0 +1,6 @@
+# Sources
+
+- [cmflib API documentation](https://hewlettpackard.github.io/cmf/cmflib/)
+- [Cmf class reference](https://hewlettpackard.github.io/cmf/api/public/cmf/)
+- [Example pipeline: parse.py, train.py, test.py](https://github.com/HewlettPackard/cmf/tree/master/examples/example-get-started/src/)
+- [Getting Started tutorial](https://hewlettpackard.github.io/cmf/examples/getting_started/)

--- a/skills/cmf-mcp/SKILL.md
+++ b/skills/cmf-mcp/SKILL.md
@@ -1,0 +1,241 @@
+---
+name: cmf-mcp
+description: >
+  Use when setting up the CMF MCP (Model Context Protocol) server so that an AI coding
+  assistant (Claude, GitHub Copilot, Cursor, etc.) can query CMF pipeline metadata,
+  artifact lineage, and model information using natural language. Also use when the CMF
+  MCP server is already running and the user wants to query CMF metadata directly from
+  their coding agent. Covers Docker deployment, per-agent configuration, using MCP tools
+  from within the agent, and multi-server setup.
+version: 1.0.0
+---
+
+First check: **is the CMF MCP server already running and configured?**
+
+Ask the user, or check for an existing `.mcp.json` / MCP configuration in their project. If the server is already available, skip to [Using CMF MCP from your coding agent](#using-cmf-mcp-from-your-coding-agent).
+
+If not yet set up, guide the user through deploying the server and connecting it to their assistant.
+
+## Prerequisites
+
+- Docker and Docker Compose installed
+- A running CMF Server (see `docs/setup/index.md` if not yet deployed)
+- An MCP-compatible AI assistant (Claude Code, GitHub Copilot in agent mode, Cursor, etc.)
+
+## What the CMF MCP server provides
+
+Once configured, your AI assistant can answer questions like:
+
+- _"What pipelines are available in CMF?"_
+- _"Show me all executions for the Train stage"_
+- _"What datasets were used in the last experiment?"_
+- _"Get the artifact lineage for models/rf.pkl"_
+- _"Show the model card for model ID 42"_
+
+## Step 1 — Clone and configure
+
+The MCP server lives in the `mcp/` directory of the CMF repository.
+
+```bash
+cd mcp/
+cp .env.example .env   # or create .env manually
+```
+
+Edit `.env` to point at your CMF Server(s):
+
+```env
+# Required: at least one CMF Server URL
+CMF_SERVER_URL=http://<your-cmf-server-host>:80
+
+# Optional: up to 4 CMF Servers for multi-environment support
+# CMF_SERVER_URL_2=http://staging-server:80
+# CMF_SERVER_URL_3=http://prod-server:80
+```
+
+## Step 2 — Start the MCP server with Docker
+
+```bash
+cd mcp/
+docker compose up -d
+```
+
+Verify it is running:
+
+```bash
+curl http://localhost:8000/health
+# {"status": "ok"}
+```
+
+The MCP server listens on port **8000** by default.
+
+## Step 3 — Connect to your AI assistant
+
+### Claude Code
+
+Create or update `.mcp.json` in your project root:
+
+```json
+{
+  "mcpServers": {
+    "cmf": {
+      "url": "http://localhost:8000/mcp",
+      "transport": "http"
+    }
+  }
+}
+```
+
+Then restart Claude Code or run `/mcp` to reload. Claude will automatically discover and use the CMF tools.
+
+### GitHub Copilot (VS Code)
+
+Open VS Code settings (`Ctrl+,` / `Cmd+,`), search for **MCP**, and add the server under **GitHub Copilot → MCP Servers**:
+
+```json
+{
+  "github.copilot.chat.mcpServers": {
+    "cmf": {
+      "url": "http://localhost:8000/mcp",
+      "transport": "http"
+    }
+  }
+}
+```
+
+Alternatively, add it to your workspace's `.vscode/settings.json`. Reload the VS Code window after saving.
+
+### Cursor
+
+Add to Cursor's MCP settings (`~/.cursor/mcp.json` or Cursor Settings → MCP → Add Server):
+
+```json
+{
+  "mcpServers": {
+    "cmf": {
+      "url": "http://localhost:8000/mcp",
+      "transport": "http"
+    }
+  }
+}
+```
+
+### Codex
+
+Add to `~/.codex/config.json`:
+
+```json
+{
+  "mcpServers": {
+    "cmf": {
+      "url": "http://localhost:8000/mcp",
+      "transport": "http"
+    }
+  }
+}
+```
+
+### Other MCP-compatible assistants
+
+Use the server URL `http://localhost:8000/mcp` with HTTP transport in your assistant's MCP configuration file.
+
+## Step 4 — Verify with natural language
+
+Once connected, test with a natural language query in your AI assistant:
+
+```
+What pipelines are available in CMF?
+```
+
+Expected: the assistant lists your pipelines by calling `cmf_show_pipelines` internally.
+
+## Available MCP tools
+
+| Tool | What it returns |
+|------|----------------|
+| `cmf_show_pipelines` | All pipeline names |
+| `cmf_show_executions` | Executions for a pipeline and stage |
+| `cmf_execution_lineage` | Full lineage tree for an execution |
+| `cmf_show_artifacts` | Artifacts filtered by type and pipeline |
+| `cmf_artifact_lineage` | Artifact lineage for a pipeline |
+| `cmf_show_model_card` | Model metadata, inputs, and training details |
+
+## Using CMF MCP from your coding agent
+
+Once the MCP server is configured, you can query CMF metadata using natural language directly in your agent's chat. The agent calls the CMF MCP tools automatically — no code required.
+
+### Example prompts
+
+**Explore pipelines:**
+```
+What pipelines are tracked in CMF?
+List the stages in the my_pipeline pipeline.
+```
+
+**Inspect executions:**
+```
+Show me all executions for the Train stage in my_pipeline.
+What hyperparameters were used in the last training run?
+```
+
+**Trace lineage:**
+```
+What datasets were used to produce models/rf.pkl?
+Show me the full artifact lineage for the production pipeline.
+Get the execution lineage for execution ID 42.
+```
+
+**Model governance:**
+```
+Show the model card for model ID 7.
+What were the evaluation metrics for the latest model?
+Which datasets were the inputs for model 7?
+```
+
+### Checking available CMF tools
+
+In Claude Code, run `/mcp` to list all connected MCP servers and their tools. You should see the `cmf` server with its six tools listed.
+
+In Cursor and GitHub Copilot, open the agent chat and type `@cmf` — the agent will show available CMF tools.
+
+In any agent, you can ask:
+```
+What CMF tools do you have available?
+```
+
+### Workflow: instrument, run, then query
+
+A typical workflow combining CMF instrumentation and MCP querying:
+
+1. Instrument your pipeline with the **cmf-instrument** skill
+2. Run your pipeline — metadata is written to the local `mlmd` file
+3. Push metadata: `cmf metadata push -p my_pipeline`
+4. Ask your agent: _"Show me the artifact lineage for the latest training run"_
+
+The agent calls `cmf_artifact_lineage` or `cmf_execution_lineage` against the CMF Server and presents the results.
+
+## Multi-server configuration
+
+To query development, staging, and production simultaneously, configure multiple server URLs in `.env`:
+
+```env
+CMF_SERVER_URL=http://dev-server:80
+CMF_SERVER_URL_2=http://staging-server:80
+CMF_SERVER_URL_3=http://prod-server:80
+```
+
+The MCP server exposes each as a separate context; your assistant can query across environments.
+
+## Troubleshooting
+
+- **`Connection refused` on port 8000**: Docker container is not running. Run `docker compose up -d` in the `mcp/` directory.
+- **`CMF Server unreachable`**: The URL in `.env` is wrong or the CMF Server is not running. Verify with `curl http://<cmf-server-host>:80/apiv1.0/health`.
+- **MCP tools not appearing in assistant**: Restart the assistant after updating `.mcp.json`. Some assistants require a full restart to reload MCP servers.
+- **Empty results from tools**: No pipelines have been pushed to the CMF Server yet. Run `cmf metadata push -p <name>` from a client machine first.
+
+## Further reading
+
+- `docs/mcp/index.md` — MCP server overview and architecture
+- `docs/mcp/quickstart.md` — Quick start guide
+- `docs/mcp/configuration.md` — Full configuration reference
+- `docs/mcp/tools.md` — Complete MCP tool reference
+- `docs/setup/index.md` — CMF Server installation

--- a/skills/cmf-mcp/SKILL.md
+++ b/skills/cmf-mcp/SKILL.md
@@ -1,241 +1,108 @@
 ---
 name: cmf-mcp
 description: >
-  Use when setting up the CMF MCP (Model Context Protocol) server so that an AI coding
-  assistant (Claude, GitHub Copilot, Cursor, etc.) can query CMF pipeline metadata,
-  artifact lineage, and model information using natural language. Also use when the CMF
-  MCP server is already running and the user wants to query CMF metadata directly from
-  their coding agent. Covers Docker deployment, per-agent configuration, using MCP tools
-  from within the agent, and multi-server setup.
+  Use when setting up the CMF MCP server so an AI coding assistant can query CMF metadata
+  using natural language, or when the CMF MCP server is already running and the user wants
+  to use it from their coding agent. Covers Docker deployment, per-agent configuration
+  (Claude Code, GitHub Copilot, Cursor, Codex), and example prompts.
 version: 1.0.0
 ---
 
-First check: **is the CMF MCP server already running and configured?**
+First check: **is the CMF MCP server already running?** Check for an existing `.mcp.json` in the project. If yes, skip to [Using CMF MCP from your coding agent](#using-cmf-mcp-from-your-coding-agent).
 
-Ask the user, or check for an existing `.mcp.json` / MCP configuration in their project. If the server is already available, skip to [Using CMF MCP from your coding agent](#using-cmf-mcp-from-your-coding-agent).
+## Prerequisites (new deployment)
 
-If not yet set up, guide the user through deploying the server and connecting it to their assistant.
+- Docker + Docker Compose
+- A running CMF Server (see [`../cmf-server/SKILL.md`](../cmf-server/SKILL.md))
+- An MCP-compatible AI assistant
 
-## Prerequisites
-
-- Docker and Docker Compose installed
-- A running CMF Server (see `docs/setup/index.md` if not yet deployed)
-- An MCP-compatible AI assistant (Claude Code, GitHub Copilot in agent mode, Cursor, etc.)
-
-## What the CMF MCP server provides
-
-Once configured, your AI assistant can answer questions like:
-
-- _"What pipelines are available in CMF?"_
-- _"Show me all executions for the Train stage"_
-- _"What datasets were used in the last experiment?"_
-- _"Get the artifact lineage for models/rf.pkl"_
-- _"Show the model card for model ID 42"_
-
-## Step 1 — Clone and configure
-
-The MCP server lives in the `mcp/` directory of the CMF repository.
+## Deploy the MCP server
 
 ```bash
 cd mcp/
-cp .env.example .env   # or create .env manually
+cp .env.example .env
 ```
 
-Edit `.env` to point at your CMF Server(s):
-
+Edit `.env`:
 ```env
-# Required: at least one CMF Server URL
 CMF_SERVER_URL=http://<your-cmf-server-host>:80
-
-# Optional: up to 4 CMF Servers for multi-environment support
+# Optional second/third server:
 # CMF_SERVER_URL_2=http://staging-server:80
-# CMF_SERVER_URL_3=http://prod-server:80
 ```
 
-## Step 2 — Start the MCP server with Docker
-
 ```bash
-cd mcp/
 docker compose up -d
+curl http://localhost:8000/health   # → {"status": "ok"}
 ```
 
-Verify it is running:
+## Connect to your coding agent
 
-```bash
-curl http://localhost:8000/health
-# {"status": "ok"}
-```
-
-The MCP server listens on port **8000** by default.
-
-## Step 3 — Connect to your AI assistant
-
-### Claude Code
-
-Create or update `.mcp.json` in your project root:
-
+### Claude Code — `.mcp.json` (project root)
 ```json
 {
   "mcpServers": {
-    "cmf": {
-      "url": "http://localhost:8000/mcp",
-      "transport": "http"
-    }
+    "cmf": { "url": "http://localhost:8000/mcp", "transport": "http" }
   }
 }
 ```
+Restart Claude Code or run `/mcp` to reload.
 
-Then restart Claude Code or run `/mcp` to reload. Claude will automatically discover and use the CMF tools.
-
-### GitHub Copilot (VS Code)
-
-Open VS Code settings (`Ctrl+,` / `Cmd+,`), search for **MCP**, and add the server under **GitHub Copilot → MCP Servers**:
-
+### GitHub Copilot — VS Code settings
 ```json
 {
   "github.copilot.chat.mcpServers": {
-    "cmf": {
-      "url": "http://localhost:8000/mcp",
-      "transport": "http"
-    }
+    "cmf": { "url": "http://localhost:8000/mcp", "transport": "http" }
   }
 }
 ```
+Add to `.vscode/settings.json` or VS Code user settings. Reload the window.
 
-Alternatively, add it to your workspace's `.vscode/settings.json`. Reload the VS Code window after saving.
-
-### Cursor
-
-Add to Cursor's MCP settings (`~/.cursor/mcp.json` or Cursor Settings → MCP → Add Server):
-
+### Cursor — `~/.cursor/mcp.json`
 ```json
 {
   "mcpServers": {
-    "cmf": {
-      "url": "http://localhost:8000/mcp",
-      "transport": "http"
-    }
+    "cmf": { "url": "http://localhost:8000/mcp", "transport": "http" }
   }
 }
 ```
 
-### Codex
-
-Add to `~/.codex/config.json`:
-
+### Codex — `~/.codex/config.json`
 ```json
 {
   "mcpServers": {
-    "cmf": {
-      "url": "http://localhost:8000/mcp",
-      "transport": "http"
-    }
+    "cmf": { "url": "http://localhost:8000/mcp", "transport": "http" }
   }
 }
 ```
 
-### Other MCP-compatible assistants
-
-Use the server URL `http://localhost:8000/mcp` with HTTP transport in your assistant's MCP configuration file.
-
-## Step 4 — Verify with natural language
-
-Once connected, test with a natural language query in your AI assistant:
-
-```
-What pipelines are available in CMF?
-```
-
-Expected: the assistant lists your pipelines by calling `cmf_show_pipelines` internally.
-
-## Available MCP tools
-
-| Tool | What it returns |
-|------|----------------|
-| `cmf_show_pipelines` | All pipeline names |
-| `cmf_show_executions` | Executions for a pipeline and stage |
-| `cmf_execution_lineage` | Full lineage tree for an execution |
-| `cmf_show_artifacts` | Artifacts filtered by type and pipeline |
-| `cmf_artifact_lineage` | Artifact lineage for a pipeline |
-| `cmf_show_model_card` | Model metadata, inputs, and training details |
+---
 
 ## Using CMF MCP from your coding agent
 
-Once the MCP server is configured, you can query CMF metadata using natural language directly in your agent's chat. The agent calls the CMF MCP tools automatically — no code required.
+Once connected, query CMF metadata in natural language:
 
-### Example prompts
-
-**Explore pipelines:**
 ```
 What pipelines are tracked in CMF?
-List the stages in the my_pipeline pipeline.
-```
-
-**Inspect executions:**
-```
-Show me all executions for the Train stage in my_pipeline.
-What hyperparameters were used in the last training run?
-```
-
-**Trace lineage:**
-```
-What datasets were used to produce models/rf.pkl?
-Show me the full artifact lineage for the production pipeline.
-Get the execution lineage for execution ID 42.
-```
-
-**Model governance:**
-```
+Show all executions for the Train stage in my_pipeline.
+What datasets produced models/rf.pkl?
 Show the model card for model ID 7.
-What were the evaluation metrics for the latest model?
-Which datasets were the inputs for model 7?
+What were the evaluation metrics for the latest run?
 ```
 
-### Checking available CMF tools
+**Check available tools** — in Claude Code run `/mcp`; in Cursor/Copilot type `@cmf` in agent chat.
 
-In Claude Code, run `/mcp` to list all connected MCP servers and their tools. You should see the `cmf` server with its six tools listed.
+**End-to-end workflow:**
+1. Instrument pipeline → `cmf metadata push -p my_pipeline` → ask the agent natural language questions
 
-In Cursor and GitHub Copilot, open the agent chat and type `@cmf` — the agent will show available CMF tools.
-
-In any agent, you can ask:
-```
-What CMF tools do you have available?
-```
-
-### Workflow: instrument, run, then query
-
-A typical workflow combining CMF instrumentation and MCP querying:
-
-1. Instrument your pipeline with the **cmf-instrument** skill
-2. Run your pipeline — metadata is written to the local `mlmd` file
-3. Push metadata: `cmf metadata push -p my_pipeline`
-4. Ask your agent: _"Show me the artifact lineage for the latest training run"_
-
-The agent calls `cmf_artifact_lineage` or `cmf_execution_lineage` against the CMF Server and presents the results.
-
-## Multi-server configuration
-
-To query development, staging, and production simultaneously, configure multiple server URLs in `.env`:
-
-```env
-CMF_SERVER_URL=http://dev-server:80
-CMF_SERVER_URL_2=http://staging-server:80
-CMF_SERVER_URL_3=http://prod-server:80
-```
-
-The MCP server exposes each as a separate context; your assistant can query across environments.
+See [references/mcp-tools.md](references/mcp-tools.md) for the full tool reference.
 
 ## Troubleshooting
 
-- **`Connection refused` on port 8000**: Docker container is not running. Run `docker compose up -d` in the `mcp/` directory.
-- **`CMF Server unreachable`**: The URL in `.env` is wrong or the CMF Server is not running. Verify with `curl http://<cmf-server-host>:80/apiv1.0/health`.
-- **MCP tools not appearing in assistant**: Restart the assistant after updating `.mcp.json`. Some assistants require a full restart to reload MCP servers.
-- **Empty results from tools**: No pipelines have been pushed to the CMF Server yet. Run `cmf metadata push -p <name>` from a client machine first.
+- **`Connection refused` on port 8000** — run `docker compose up -d` in `mcp/`
+- **CMF Server unreachable** — verify with `curl http://<cmf-server>:80/apiv1.0/pipelines`
+- **Tools not appearing** — restart the agent after updating `.mcp.json`
+- **Empty results** — push metadata first: `cmf metadata push -p <name>`
 
-## Further reading
+---
 
-- `docs/mcp/index.md` — MCP server overview and architecture
-- `docs/mcp/quickstart.md` — Quick start guide
-- `docs/mcp/configuration.md` — Full configuration reference
-- `docs/mcp/tools.md` — Complete MCP tool reference
-- `docs/setup/index.md` — CMF Server installation
+**Docs:** [MCP Server overview](https://hewlettpackard.github.io/cmf/mcp/) · [Quick Start](https://hewlettpackard.github.io/cmf/mcp/quickstart/) · [Configuration](https://hewlettpackard.github.io/cmf/mcp/configuration/) · [Tools Reference](https://hewlettpackard.github.io/cmf/mcp/tools/)

--- a/skills/cmf-mcp/SKILL.md
+++ b/skills/cmf-mcp/SKILL.md
@@ -20,14 +20,15 @@ First check: **is the CMF MCP server already running?** Check for an existing `.
 
 ```bash
 cd mcp/
-cp .env.example .env
+cp example.env .env
 ```
 
 Edit `.env`:
 ```env
-CMF_SERVER_URL=http://<your-cmf-server-host>:80
-# Optional second/third server:
-# CMF_SERVER_URL_2=http://staging-server:80
+CMF_BASE_URL=http://<your-cmf-server-host>:80
+# Optional second/third/fourth server:
+# CMF2_BASE_URL=http://staging-server:80
+# CMF3_BASE_URL=http://another-server:80
 ```
 
 ```bash

--- a/skills/cmf-mcp/references/mcp-tools.md
+++ b/skills/cmf-mcp/references/mcp-tools.md
@@ -25,8 +25,9 @@ The CMF MCP server exposes six tools to AI assistants.
 
 Configure up to 4 CMF Servers in `.env`:
 ```env
-CMF_SERVER_URL=http://dev-server:80
-CMF_SERVER_URL_2=http://staging-server:80
-CMF_SERVER_URL_3=http://prod-server:80
+CMF_BASE_URL=http://dev-server:80
+CMF2_BASE_URL=http://staging-server:80
+CMF3_BASE_URL=http://prod-server:80
+# CMF4_BASE_URL=http://another-server:80
 ```
 Each server is exposed as a separate context; the assistant can query across environments.

--- a/skills/cmf-mcp/references/mcp-tools.md
+++ b/skills/cmf-mcp/references/mcp-tools.md
@@ -1,0 +1,32 @@
+# CMF MCP Tools Reference
+
+The CMF MCP server exposes six tools to AI assistants.
+
+| Tool | Parameters | Returns |
+|------|-----------|---------|
+| `cmf_show_pipelines` | none | All pipeline names |
+| `cmf_show_executions` | `pipeline`, `stage` (optional) | Executions with properties |
+| `cmf_execution_lineage` | `execution_id` | Full lineage tree for an execution |
+| `cmf_show_artifacts` | `pipeline`, `type` (optional) | Artifacts filtered by type |
+| `cmf_artifact_lineage` | `pipeline` | Artifact lineage graph for a pipeline |
+| `cmf_show_model_card` | `model_id` | Model metadata, inputs, training details, metrics |
+
+## Example natural language → tool mapping
+
+| User asks | Tool called |
+|-----------|------------|
+| "What pipelines are in CMF?" | `cmf_show_pipelines` |
+| "List executions for Train stage" | `cmf_show_executions` |
+| "What's the lineage for execution 42?" | `cmf_execution_lineage(execution_id=42)` |
+| "Show datasets in my_pipeline" | `cmf_show_artifacts(pipeline="my_pipeline", type="Dataset")` |
+| "Show the model card for model 7" | `cmf_show_model_card(model_id=7)` |
+
+## Multi-server support
+
+Configure up to 4 CMF Servers in `.env`:
+```env
+CMF_SERVER_URL=http://dev-server:80
+CMF_SERVER_URL_2=http://staging-server:80
+CMF_SERVER_URL_3=http://prod-server:80
+```
+Each server is exposed as a separate context; the assistant can query across environments.

--- a/skills/cmf-mcp/sources.md
+++ b/skills/cmf-mcp/sources.md
@@ -1,0 +1,7 @@
+# Sources
+
+- [MCP Server overview](https://hewlettpackard.github.io/cmf/mcp/)
+- [MCP Quick Start](https://hewlettpackard.github.io/cmf/mcp/quickstart/)
+- [MCP Configuration](https://hewlettpackard.github.io/cmf/mcp/configuration/)
+- [MCP Tools Reference](https://hewlettpackard.github.io/cmf/mcp/tools/)
+- `mcp/main.py`, `mcp/tools/` — tool implementations

--- a/skills/cmf-query/SKILL.md
+++ b/skills/cmf-query/SKILL.md
@@ -1,204 +1,86 @@
 ---
 name: cmf-query
 description: >
-  Use when querying CMF metadata programmatically — listing pipelines, stages, and
-  executions; retrieving artifact lineage; exploring relationships between datasets,
-  models, and executions; or exporting metadata for analysis. Uses the CmfQuery
-  Python API and the CMF CLI listing commands.
+  Use when querying CMF metadata programmatically — listing pipelines, stages, executions,
+  artifacts; tracing lineage; comparing hyperparameters across runs; or exporting metadata
+  for analysis. Uses the CmfQuery Python API or CLI listing commands.
 version: 1.0.0
 ---
 
-Help the user query CMF metadata using the `CmfQuery` Python API or CLI commands. Identify what they want to find (pipeline overview, artifact lineage, execution history, specific artifacts) and write the correct query.
+Write the query the user needs using `CmfQuery` or the CMF CLI. Identify what they want to find (pipeline overview, lineage, hyperparameter comparison, specific artifacts) and produce the code.
 
-## Two ways to query CMF
-
-| Method | When to use |
-|--------|------------|
-| `CmfQuery` Python API | Custom scripts, analysis notebooks, automation |
-| CMF CLI (`cmf pipeline/execution/artifact list`) | Quick inspection from the terminal |
-
-## CmfQuery Python API
-
-### Initialize
+## Initialize
 
 ```python
 from cmflib.cmfquery import CmfQuery
-
-# Point to the local mlmd file (or a downloaded one)
-query = CmfQuery(filepath="mlmd")
+query = CmfQuery(filepath="mlmd")   # or path to a downloaded mlmd file
 ```
 
-### List pipelines
+## Common patterns
 
+### List pipelines and stages
 ```python
-pipelines = query.get_pipeline_names()
-print(pipelines)
-# ['my_pipeline', 'experiment_v2']
+pipelines = query.get_pipeline_names()           # ['my_pipeline', ...]
+stages = query.get_pipeline_stages("my_pipeline") # ['Prepare', 'Train', ...]
 ```
 
-### List stages in a pipeline
-
+### Executions with hyperparameters
 ```python
-stages = query.get_pipeline_stages("my_pipeline")
-print(stages)
-# ['Prepare', 'Train', 'Evaluate']
-```
-
-### List executions in a stage
-
-```python
-import pandas as pd
-
-executions: pd.DataFrame = query.get_all_executions_in_stage("Train")
-print(executions[["name", "id", "learning_rate", "n_estimators"]])
-```
-
-Returns a `pandas.DataFrame` with one row per execution and columns for all logged custom properties.
-
-### Get all executions for a pipeline
-
-```python
-executions = query.get_all_executions_in_pipeline("my_pipeline")
-```
-
-### Get a specific artifact
-
-```python
-artifact = query.get_artifact("data/train.csv")
-print(artifact)
-```
-
-### Get all artifacts in a pipeline
-
-```python
-datasets = query.get_all_artifacts_for_pipeline("my_pipeline")
-print(datasets)
-```
-
-### Get artifact lineage — one hop upstream
-
-```python
-# What artifacts fed INTO this artifact?
-parents = query.get_one_hop_parent_artifacts("models/rf.pkl")
-```
-
-### Get artifact lineage — one hop downstream
-
-```python
-# What artifacts were produced FROM this artifact?
-children = query.get_one_hop_child_artifacts("data/train.csv")
-```
-
-### Get parent executions of an artifact
-
-```python
-# Which executions produced this artifact?
-parent_executions = query.get_one_hop_parent_executions("models/rf.pkl")
-```
-
-### Get all executions for a pipeline (DataFrame)
-
-```python
-all_executions = query.get_all_executions_in_pipeline("my_pipeline")
-# Filter to a specific stage
-train_runs = all_executions[all_executions["type"] == "Train"]
-```
-
-## Common query patterns
-
-### Compare hyperparameters across training runs
-
-```python
-from cmflib.cmfquery import CmfQuery
-import pandas as pd
-
-query = CmfQuery(filepath="mlmd")
 runs = query.get_all_executions_in_stage("Train")
-
-# Show learning_rate and accuracy for each run
-comparison = runs[["name", "learning_rate", "n_estimators"]].copy()
-print(comparison.sort_values("learning_rate"))
+# runs is a pandas DataFrame — one row per run, columns = custom_properties
+print(runs[["name", "learning_rate", "n_estimators"]])
 ```
 
-### Trace a model's full data lineage
-
+### Artifact lineage
 ```python
-from cmflib.cmfquery import CmfQuery
+# What fed INTO this artifact?
+parents = query.get_one_hop_parent_artifacts("models/rf.pkl")
 
-query = CmfQuery(filepath="mlmd")
+# What was produced FROM this artifact?
+children = query.get_one_hop_child_artifacts("data/train.csv")
 
-model_path = "models/rf.pkl"
-print(f"Parents of {model_path}:")
-parents = query.get_one_hop_parent_artifacts(model_path)
-print(parents)
-
-for parent in parents["name"].tolist():
-    print(f"  Parents of {parent}:")
-    grandparents = query.get_one_hop_parent_artifacts(parent)
-    print(grandparents)
+# Which execution produced this artifact?
+execs = query.get_one_hop_parent_executions("models/rf.pkl")
 ```
 
-### Find all models produced by a pipeline
-
+### Compare runs across a stage
 ```python
-from cmflib.cmfquery import CmfQuery
+runs = query.get_all_executions_in_stage("Train")
+print(runs[["name", "learning_rate", "n_estimators"]].sort_values("learning_rate"))
+```
 
-query = CmfQuery(filepath="mlmd")
+### Walk full lineage (two hops)
+```python
+model = "models/rf.pkl"
+parents = query.get_one_hop_parent_artifacts(model)
+for p in parents["name"].tolist():
+    grandparents = query.get_one_hop_parent_artifacts(p)
+    print(f"{p} ← {grandparents['name'].tolist()}")
+```
+
+### All models in a pipeline
+```python
 artifacts = query.get_all_artifacts_for_pipeline("my_pipeline")
 models = artifacts[artifacts["type"] == "Model"]
-print(models[["name", "id", "uri"]])
-```
-
-### List all datasets consumed by a stage
-
-```python
-from cmflib.cmfquery import CmfQuery
-
-query = CmfQuery(filepath="mlmd")
-executions = query.get_all_executions_in_stage("Train")
-
-for exec_id in executions["id"]:
-    inputs = query.get_all_artifacts_for_execution(exec_id, event="input")
-    print(f"Execution {exec_id} inputs:", inputs["name"].tolist())
+print(models[["name", "uri"]])
 ```
 
 ## CLI quick inspection
 
 ```bash
-# List all pipelines in the local mlmd
 cmf pipeline list
-
-# List executions for a pipeline
 cmf execution list -p my_pipeline
-
-# List artifacts for a pipeline
-cmf artifact list -p my_pipeline
+cmf artifact list  -p my_pipeline
 ```
 
-## CmfQuery quick reference
-
-| Method | Returns | Purpose |
-|--------|---------|---------|
-| `get_pipeline_names()` | `list[str]` | All pipeline names |
-| `get_pipeline_stages(pipeline)` | `list[str]` | Stage names in a pipeline |
-| `get_all_executions_in_stage(stage)` | `DataFrame` | All executions for a stage |
-| `get_all_executions_in_pipeline(pipeline)` | `DataFrame` | All executions in a pipeline |
-| `get_artifact(name)` | `dict` | Single artifact by name/path |
-| `get_all_artifacts_for_pipeline(pipeline)` | `DataFrame` | All artifacts in a pipeline |
-| `get_all_artifacts_for_execution(exec_id, event)` | `DataFrame` | Artifacts for one execution |
-| `get_one_hop_parent_artifacts(artifact)` | `DataFrame` | Direct parents of an artifact |
-| `get_one_hop_child_artifacts(artifact)` | `DataFrame` | Direct children of an artifact |
-| `get_one_hop_parent_executions(artifact)` | `DataFrame` | Executions that produced an artifact |
+See [references/query-api.md](references/query-api.md) for the full CmfQuery method reference.
 
 ## Troubleshooting
 
-- **`mlmd file not found`**: Pass the correct path to `CmfQuery(filepath=...)`. Run `cmf metadata pull -p <name>` first if querying a teammate's runs.
-- **Empty DataFrame returned**: The pipeline name or stage name might not match what was logged. Check with `query.get_pipeline_names()` and `query.get_pipeline_stages(pipeline)`.
-- **`AttributeError` on query result**: Query methods return `pandas.DataFrame`; use `.tolist()`, `.itertuples()`, or standard DataFrame operations to iterate.
+- **Empty DataFrame** — check pipeline/stage names with `get_pipeline_names()` / `get_pipeline_stages(pipeline)`
+- **`mlmd file not found`** — run `cmf metadata pull -p <name>` first if querying a teammate's data
+- **`AttributeError`** — query results are `pandas.DataFrame`; use `.tolist()` or standard DataFrame operations
 
-## Further reading
+---
 
-- `docs/api/public/cmfquery.md` — Complete CmfQuery API reference
-- `docs/ui/lineage.md` — Web UI lineage graph visualization
-- `docs/ui/executions.md` — Web UI execution browser
-- `docs/mcp/index.md` — Natural language queries via AI assistant + MCP server
+**Docs:** [CmfQuery API reference](https://hewlettpackard.github.io/cmf/api/public/cmfquery/) · [Web UI executions](https://hewlettpackard.github.io/cmf/ui/executions/) · [Web UI lineage](https://hewlettpackard.github.io/cmf/ui/lineage/) · [MCP for natural language queries](https://hewlettpackard.github.io/cmf/mcp/)

--- a/skills/cmf-query/SKILL.md
+++ b/skills/cmf-query/SKILL.md
@@ -1,0 +1,204 @@
+---
+name: cmf-query
+description: >
+  Use when querying CMF metadata programmatically — listing pipelines, stages, and
+  executions; retrieving artifact lineage; exploring relationships between datasets,
+  models, and executions; or exporting metadata for analysis. Uses the CmfQuery
+  Python API and the CMF CLI listing commands.
+version: 1.0.0
+---
+
+Help the user query CMF metadata using the `CmfQuery` Python API or CLI commands. Identify what they want to find (pipeline overview, artifact lineage, execution history, specific artifacts) and write the correct query.
+
+## Two ways to query CMF
+
+| Method | When to use |
+|--------|------------|
+| `CmfQuery` Python API | Custom scripts, analysis notebooks, automation |
+| CMF CLI (`cmf pipeline/execution/artifact list`) | Quick inspection from the terminal |
+
+## CmfQuery Python API
+
+### Initialize
+
+```python
+from cmflib.cmfquery import CmfQuery
+
+# Point to the local mlmd file (or a downloaded one)
+query = CmfQuery(filepath="mlmd")
+```
+
+### List pipelines
+
+```python
+pipelines = query.get_pipeline_names()
+print(pipelines)
+# ['my_pipeline', 'experiment_v2']
+```
+
+### List stages in a pipeline
+
+```python
+stages = query.get_pipeline_stages("my_pipeline")
+print(stages)
+# ['Prepare', 'Train', 'Evaluate']
+```
+
+### List executions in a stage
+
+```python
+import pandas as pd
+
+executions: pd.DataFrame = query.get_all_executions_in_stage("Train")
+print(executions[["name", "id", "learning_rate", "n_estimators"]])
+```
+
+Returns a `pandas.DataFrame` with one row per execution and columns for all logged custom properties.
+
+### Get all executions for a pipeline
+
+```python
+executions = query.get_all_executions_in_pipeline("my_pipeline")
+```
+
+### Get a specific artifact
+
+```python
+artifact = query.get_artifact("data/train.csv")
+print(artifact)
+```
+
+### Get all artifacts in a pipeline
+
+```python
+datasets = query.get_all_artifacts_for_pipeline("my_pipeline")
+print(datasets)
+```
+
+### Get artifact lineage — one hop upstream
+
+```python
+# What artifacts fed INTO this artifact?
+parents = query.get_one_hop_parent_artifacts("models/rf.pkl")
+```
+
+### Get artifact lineage — one hop downstream
+
+```python
+# What artifacts were produced FROM this artifact?
+children = query.get_one_hop_child_artifacts("data/train.csv")
+```
+
+### Get parent executions of an artifact
+
+```python
+# Which executions produced this artifact?
+parent_executions = query.get_one_hop_parent_executions("models/rf.pkl")
+```
+
+### Get all executions for a pipeline (DataFrame)
+
+```python
+all_executions = query.get_all_executions_in_pipeline("my_pipeline")
+# Filter to a specific stage
+train_runs = all_executions[all_executions["type"] == "Train"]
+```
+
+## Common query patterns
+
+### Compare hyperparameters across training runs
+
+```python
+from cmflib.cmfquery import CmfQuery
+import pandas as pd
+
+query = CmfQuery(filepath="mlmd")
+runs = query.get_all_executions_in_stage("Train")
+
+# Show learning_rate and accuracy for each run
+comparison = runs[["name", "learning_rate", "n_estimators"]].copy()
+print(comparison.sort_values("learning_rate"))
+```
+
+### Trace a model's full data lineage
+
+```python
+from cmflib.cmfquery import CmfQuery
+
+query = CmfQuery(filepath="mlmd")
+
+model_path = "models/rf.pkl"
+print(f"Parents of {model_path}:")
+parents = query.get_one_hop_parent_artifacts(model_path)
+print(parents)
+
+for parent in parents["name"].tolist():
+    print(f"  Parents of {parent}:")
+    grandparents = query.get_one_hop_parent_artifacts(parent)
+    print(grandparents)
+```
+
+### Find all models produced by a pipeline
+
+```python
+from cmflib.cmfquery import CmfQuery
+
+query = CmfQuery(filepath="mlmd")
+artifacts = query.get_all_artifacts_for_pipeline("my_pipeline")
+models = artifacts[artifacts["type"] == "Model"]
+print(models[["name", "id", "uri"]])
+```
+
+### List all datasets consumed by a stage
+
+```python
+from cmflib.cmfquery import CmfQuery
+
+query = CmfQuery(filepath="mlmd")
+executions = query.get_all_executions_in_stage("Train")
+
+for exec_id in executions["id"]:
+    inputs = query.get_all_artifacts_for_execution(exec_id, event="input")
+    print(f"Execution {exec_id} inputs:", inputs["name"].tolist())
+```
+
+## CLI quick inspection
+
+```bash
+# List all pipelines in the local mlmd
+cmf pipeline list
+
+# List executions for a pipeline
+cmf execution list -p my_pipeline
+
+# List artifacts for a pipeline
+cmf artifact list -p my_pipeline
+```
+
+## CmfQuery quick reference
+
+| Method | Returns | Purpose |
+|--------|---------|---------|
+| `get_pipeline_names()` | `list[str]` | All pipeline names |
+| `get_pipeline_stages(pipeline)` | `list[str]` | Stage names in a pipeline |
+| `get_all_executions_in_stage(stage)` | `DataFrame` | All executions for a stage |
+| `get_all_executions_in_pipeline(pipeline)` | `DataFrame` | All executions in a pipeline |
+| `get_artifact(name)` | `dict` | Single artifact by name/path |
+| `get_all_artifacts_for_pipeline(pipeline)` | `DataFrame` | All artifacts in a pipeline |
+| `get_all_artifacts_for_execution(exec_id, event)` | `DataFrame` | Artifacts for one execution |
+| `get_one_hop_parent_artifacts(artifact)` | `DataFrame` | Direct parents of an artifact |
+| `get_one_hop_child_artifacts(artifact)` | `DataFrame` | Direct children of an artifact |
+| `get_one_hop_parent_executions(artifact)` | `DataFrame` | Executions that produced an artifact |
+
+## Troubleshooting
+
+- **`mlmd file not found`**: Pass the correct path to `CmfQuery(filepath=...)`. Run `cmf metadata pull -p <name>` first if querying a teammate's runs.
+- **Empty DataFrame returned**: The pipeline name or stage name might not match what was logged. Check with `query.get_pipeline_names()` and `query.get_pipeline_stages(pipeline)`.
+- **`AttributeError` on query result**: Query methods return `pandas.DataFrame`; use `.tolist()`, `.itertuples()`, or standard DataFrame operations to iterate.
+
+## Further reading
+
+- `docs/api/public/cmfquery.md` — Complete CmfQuery API reference
+- `docs/ui/lineage.md` — Web UI lineage graph visualization
+- `docs/ui/executions.md` — Web UI execution browser
+- `docs/mcp/index.md` — Natural language queries via AI assistant + MCP server

--- a/skills/cmf-query/references/query-api.md
+++ b/skills/cmf-query/references/query-api.md
@@ -1,0 +1,23 @@
+# CmfQuery API Reference
+
+```python
+from cmflib.cmfquery import CmfQuery
+query = CmfQuery(filepath="mlmd")
+```
+
+## Method reference
+
+| Method | Returns | Purpose |
+|--------|---------|---------|
+| `get_pipeline_names()` | `list[str]` | All pipeline names |
+| `get_pipeline_stages(pipeline)` | `list[str]` | Stage names in a pipeline |
+| `get_all_executions_in_stage(stage)` | `DataFrame` | All executions for a stage, with custom_properties as columns |
+| `get_all_executions_in_pipeline(pipeline)` | `DataFrame` | All executions in a pipeline |
+| `get_artifact(name)` | `dict` | Single artifact by name/path |
+| `get_all_artifacts_for_pipeline(pipeline)` | `DataFrame` | All artifacts in a pipeline |
+| `get_all_artifacts_for_execution(exec_id, event)` | `DataFrame` | Artifacts for one execution |
+| `get_one_hop_parent_artifacts(artifact)` | `DataFrame` | Direct parents of an artifact |
+| `get_one_hop_child_artifacts(artifact)` | `DataFrame` | Direct children of an artifact |
+| `get_one_hop_parent_executions(artifact)` | `DataFrame` | Executions that produced an artifact |
+
+All DataFrame-returning methods return `pandas.DataFrame`. Use standard DataFrame operations (`.tolist()`, filtering, `.sort_values()`) to process results.

--- a/skills/cmf-query/sources.md
+++ b/skills/cmf-query/sources.md
@@ -1,0 +1,5 @@
+# Sources
+
+- [CmfQuery API reference](https://hewlettpackard.github.io/cmf/api/public/cmfquery/)
+- [Web UI executions](https://hewlettpackard.github.io/cmf/ui/executions/)
+- [Web UI lineage](https://hewlettpackard.github.io/cmf/ui/lineage/)

--- a/skills/cmf-server/SKILL.md
+++ b/skills/cmf-server/SKILL.md
@@ -1,141 +1,69 @@
 ---
 name: cmf-server
 description: >
-  Use when deploying the CMF Server locally with Docker Compose, or when connecting
-  to an existing shared CMF Server using credentials. Covers editing the .env file,
-  configuring PostgreSQL, starting containers, verifying the web UI, and pointing
-  cmflib clients at the server. If a CMF Server is already running and the user has
-  a URL and credentials, skip to the connection section.
+  Use when deploying the CMF Server locally with Docker Compose, or connecting to an
+  existing shared CMF Server. Covers creating the .env file, starting the container
+  stack, verifying the web UI, and pointing cmflib clients at the server. If a server
+  is already running and credentials are available, skip to the connection section.
 version: 1.0.0
 ---
 
-First check: **is a CMF Server already available?**
+First check: **is a CMF Server already running?** If yes, skip to [Connecting to an existing server](#connecting-to-an-existing-cmf-server).
 
-Ask the user whether a teammate or administrator has already deployed a CMF Server. If yes, and they have the server URL and credentials, skip to [Connecting to an existing CMF Server](#connecting-to-an-existing-cmf-server).
+## Local deployment
 
-If not, guide the user through a local Docker Compose deployment below.
+### Prerequisites
+- Docker Engine + Docker Compose plugin
+- Host IP or hostname (for `REACT_APP_CMF_API_URL`)
+- Ports 80 and 443 free (configurable)
 
-## Prerequisites (local deployment)
-
-- Docker Engine with Docker Compose plugin installed
-- Git (to clone the CMF repository)
-- Ports 80 and 443 free on the host (configurable)
-- The host machine's IP address or hostname (for `REACT_APP_CMF_API_URL`)
-
-## Step 1 — Clone the CMF repository
+### Step 1 — Clone CMF
 
 ```bash
 git clone https://github.com/HewlettPackard/cmf
 cd cmf
 ```
 
-## Step 2 — Create the `.env` file
+### Step 2 — Create `.env`
 
-The `docker-compose-server.yml` file reads configuration from a `.env` file in the same directory. Create it:
-
-```bash
-cat > .env << 'EOF'
-# Data storage — where PostgreSQL, TensorBoard logs, and uploaded files live.
-# Use an absolute path for production deployments.
+```env
 CMF_DATA_DIR=./data
-
-# Nginx port bindings
 NGINX_HTTP_PORT=80
 NGINX_HTTPS_PORT=443
-
-# The URL clients and the UI use to reach the CMF API.
-# Replace with your server's IP or hostname. Must be reachable from browsers and cmflib clients.
 REACT_APP_CMF_API_URL=http://<your-server-ip>:80
 
-# PostgreSQL credentials (change from defaults in production)
 POSTGRES_USER=myuser
-POSTGRES_PASSWORD=mypassword
+POSTGRES_PASSWORD=mypassword    # change in production
 POSTGRES_DB=mlmd
 POSTGRES_HOST=postgres
 POSTGRES_PORT=5432
 
-# MCP server — external port for the CMF MCP server (default 8382)
 MCP_EXTERNAL_PORT=8382
-EOF
 ```
 
-### Key `.env` variables explained
+See [references/env-variables.md](references/env-variables.md) for full variable descriptions and common customizations.
 
-| Variable | Default | Purpose |
-|----------|---------|---------|
-| `CMF_DATA_DIR` | `./data` | Host path for all persistent data (PostgreSQL, logs, uploads) |
-| `NGINX_HTTP_PORT` | `80` | Host port for HTTP traffic |
-| `NGINX_HTTPS_PORT` | `443` | Host port for HTTPS traffic |
-| `REACT_APP_CMF_API_URL` | _(required)_ | Full URL clients use to reach the API — must match actual host address |
-| `POSTGRES_USER` | `myuser` | PostgreSQL username |
-| `POSTGRES_PASSWORD` | `mypassword` | PostgreSQL password — **change this in production** |
-| `POSTGRES_DB` | `mlmd` | Database name |
-| `MCP_EXTERNAL_PORT` | `8382` | Host port mapped to the CMF MCP server |
-
-### Common `.env` customizations
-
-**Use a non-standard port (if 80 is taken):**
-```env
-NGINX_HTTP_PORT=8080
-REACT_APP_CMF_API_URL=http://<your-server-ip>:8080
-```
-
-**Store data on a specific volume or NFS mount:**
-```env
-CMF_DATA_DIR=/mnt/nfs/cmf-data
-```
-
-**Expose PostgreSQL externally (uncomment the ports section in docker-compose-server.yml):**
-```env
-POSTGRES_PORT=5432
-```
-
-## Step 3 — Build and start the containers
+### Step 3 — Start
 
 ```bash
 docker compose -f docker-compose-server.yml up -d
+docker compose -f docker-compose-server.yml ps   # all services should be healthy within ~60s
 ```
 
-This starts five services:
+Services started: `postgres`, `server` (CMF API), `ui` (React), `tensorboard`, `nginx`, `mcp`.
 
-| Service | Role |
-|---------|------|
-| `postgres` | Metadata database (starts first) |
-| `server` | CMF API server (waits for postgres health check) |
-| `ui` | React web interface (waits for server health check) |
-| `tensorboard` | Training metrics visualization |
-| `nginx` | Reverse proxy on ports 80/443 |
-| `mcp` | CMF MCP server on `MCP_EXTERNAL_PORT` |
-
-Check that all containers are healthy:
-
-```bash
-docker compose -f docker-compose-server.yml ps
-```
-
-All services should show `healthy` or `running` within ~60 seconds.
-
-## Step 4 — Verify the web UI
-
-Open a browser and navigate to:
-
-```
-http://<your-server-ip>:80
-```
-
-(or whatever port you set in `NGINX_HTTP_PORT`). The CMF web UI should load and show an empty pipelines list.
-
-Verify the API is responding:
+### Step 4 — Verify
 
 ```bash
 curl http://<your-server-ip>:80/apiv1.0/pipelines
 # {"pipelines": []}
 ```
 
-## Step 5 — Point cmflib clients at this server
+Open `http://<your-server-ip>:80` in a browser — CMF web UI should load.
 
-On each client machine that will push/pull metadata, run `cmf init` with the `--cmf-server-url` flag pointing at this server:
+### Step 5 — Point clients at the server
 
+On each client machine:
 ```bash
 cmf init local \
   --path /path/to/artifact-storage \
@@ -143,71 +71,33 @@ cmf init local \
   --cmf-server-url http://<your-server-ip>:80
 ```
 
-Confirm the client is configured:
-
-```bash
-cmf init show
-# Should show CMF Server URL: http://<your-server-ip>:80
-```
-
-Push a pipeline's metadata to verify end-to-end:
-
-```bash
-cmf metadata push -p my_pipeline
-```
-
 ---
 
 ## Connecting to an existing CMF Server
 
-If a CMF Server is already running, skip the Docker setup entirely and just point your local CMF client at it.
-
-### Configure the client
-
 ```bash
-# Re-initialize CMF with the server URL (keeps existing storage backend config)
 cmf init local \
   --path /path/to/artifact-storage \
   --git-remote-url https://github.com/your-org/your-repo.git \
   --cmf-server-url http://<server-url>:<port>
+
+cmf init show                       # verify the URL is set
+cmf metadata pull -p my_pipeline    # confirm access
 ```
 
-Or, if CMF is already initialized and you only want to update the server URL, re-run `cmf init` — it will update the configuration in place.
-
-### Verify connectivity
-
-```bash
-cmf init show   # confirm the server URL is set
-cmf pipeline list   # should list pipelines on the remote server (after a pull)
-cmf metadata pull -p my_pipeline   # fetch a pipeline's metadata to confirm access
-```
-
-### What credentials are needed?
-
-The CMF Server does not use username/password authentication by default. Access is controlled at the network level (firewall rules, VPN). If your organization has added an authentication layer in front of the server (e.g. Nginx basic auth or an SSO proxy), ask your administrator for the necessary credentials or token and configure them in your HTTP client or `~/.netrc`.
+The CMF Server uses network-level access control (no built-in username/password by default). If your deployment has an auth proxy, ask the administrator for credentials.
 
 ---
 
-## Stopping and managing the server
+## Manage the server
 
 ```bash
-# Stop containers (data is preserved)
-docker compose -f docker-compose-server.yml stop
-
-# Start again
-docker compose -f docker-compose-server.yml start
-
-# Remove containers (data in CMF_DATA_DIR is preserved)
-docker compose -f docker-compose-server.yml down
-
-# Remove containers AND all data (destructive — backup first)
-docker compose -f docker-compose-server.yml down -v
-rm -rf ./data
+docker compose -f docker-compose-server.yml stop    # stop (data preserved)
+docker compose -f docker-compose-server.yml start   # restart
+docker compose -f docker-compose-server.yml down    # remove containers (data preserved in CMF_DATA_DIR)
 ```
 
-## Upgrading the server
-
-After pulling a new version of the CMF repository, rebuild images before restarting:
+## Upgrade
 
 ```bash
 git pull
@@ -217,16 +107,11 @@ docker compose -f docker-compose-server.yml up -d
 
 ## Troubleshooting
 
-- **`REACT_APP_CMF_API_URL` not set**: The `server` and `ui` containers will fail to start. This variable is required — set it to the server's actual IP or hostname.
-- **Port 80 already in use**: Change `NGINX_HTTP_PORT` in `.env` and update `REACT_APP_CMF_API_URL` to match.
-- **`postgres` container not healthy**: Check PostgreSQL logs with `docker compose -f docker-compose-server.yml logs postgres`. Usually a permission issue with `CMF_DATA_DIR`.
-- **UI loads but API calls fail**: `REACT_APP_CMF_API_URL` must be reachable from the browser, not just the Docker network. Use the host machine's IP, not `localhost`, when accessing from other machines.
-- **MCP server not reachable**: Check `MCP_EXTERNAL_PORT` in `.env` and confirm it is not blocked by a firewall. Test with `curl http://<server-ip>:<MCP_EXTERNAL_PORT>/health`.
-- **Clients cannot push metadata**: Confirm `cmf init show` shows the correct server URL. Ensure the server port is reachable from the client (`curl http://<server-ip>:80/apiv1.0/pipelines`).
+- **`REACT_APP_CMF_API_URL` not set** — required; set to the host's IP/hostname
+- **Port 80 in use** — change `NGINX_HTTP_PORT` and update `REACT_APP_CMF_API_URL` to match
+- **`postgres` not healthy** — check `docker compose ... logs postgres`; often a `CMF_DATA_DIR` permissions issue
+- **UI loads but API calls fail** — use the host IP, not `localhost`, in `REACT_APP_CMF_API_URL`
 
-## Further reading
+---
 
-- `docs/setup/index.md` — Full installation guide with Docker prerequisites
-- `docs/cmf_client/index.md` — CMF Client CLI guide and push/pull workflow
-- `docs/ui/index.md` — Web UI reference
-- `docs/mcp/index.md` — CMF MCP server (included in docker-compose-server.yml)
+**Docs:** [Installation Guide](https://hewlettpackard.github.io/cmf/setup/) · [CMF Client Guide](https://hewlettpackard.github.io/cmf/cmf_client/) · [Web UI Reference](https://hewlettpackard.github.io/cmf/ui/lineage/)

--- a/skills/cmf-server/SKILL.md
+++ b/skills/cmf-server/SKILL.md
@@ -1,0 +1,232 @@
+---
+name: cmf-server
+description: >
+  Use when deploying the CMF Server locally with Docker Compose, or when connecting
+  to an existing shared CMF Server using credentials. Covers editing the .env file,
+  configuring PostgreSQL, starting containers, verifying the web UI, and pointing
+  cmflib clients at the server. If a CMF Server is already running and the user has
+  a URL and credentials, skip to the connection section.
+version: 1.0.0
+---
+
+First check: **is a CMF Server already available?**
+
+Ask the user whether a teammate or administrator has already deployed a CMF Server. If yes, and they have the server URL and credentials, skip to [Connecting to an existing CMF Server](#connecting-to-an-existing-cmf-server).
+
+If not, guide the user through a local Docker Compose deployment below.
+
+## Prerequisites (local deployment)
+
+- Docker Engine with Docker Compose plugin installed
+- Git (to clone the CMF repository)
+- Ports 80 and 443 free on the host (configurable)
+- The host machine's IP address or hostname (for `REACT_APP_CMF_API_URL`)
+
+## Step 1 — Clone the CMF repository
+
+```bash
+git clone https://github.com/HewlettPackard/cmf
+cd cmf
+```
+
+## Step 2 — Create the `.env` file
+
+The `docker-compose-server.yml` file reads configuration from a `.env` file in the same directory. Create it:
+
+```bash
+cat > .env << 'EOF'
+# Data storage — where PostgreSQL, TensorBoard logs, and uploaded files live.
+# Use an absolute path for production deployments.
+CMF_DATA_DIR=./data
+
+# Nginx port bindings
+NGINX_HTTP_PORT=80
+NGINX_HTTPS_PORT=443
+
+# The URL clients and the UI use to reach the CMF API.
+# Replace with your server's IP or hostname. Must be reachable from browsers and cmflib clients.
+REACT_APP_CMF_API_URL=http://<your-server-ip>:80
+
+# PostgreSQL credentials (change from defaults in production)
+POSTGRES_USER=myuser
+POSTGRES_PASSWORD=mypassword
+POSTGRES_DB=mlmd
+POSTGRES_HOST=postgres
+POSTGRES_PORT=5432
+
+# MCP server — external port for the CMF MCP server (default 8382)
+MCP_EXTERNAL_PORT=8382
+EOF
+```
+
+### Key `.env` variables explained
+
+| Variable | Default | Purpose |
+|----------|---------|---------|
+| `CMF_DATA_DIR` | `./data` | Host path for all persistent data (PostgreSQL, logs, uploads) |
+| `NGINX_HTTP_PORT` | `80` | Host port for HTTP traffic |
+| `NGINX_HTTPS_PORT` | `443` | Host port for HTTPS traffic |
+| `REACT_APP_CMF_API_URL` | _(required)_ | Full URL clients use to reach the API — must match actual host address |
+| `POSTGRES_USER` | `myuser` | PostgreSQL username |
+| `POSTGRES_PASSWORD` | `mypassword` | PostgreSQL password — **change this in production** |
+| `POSTGRES_DB` | `mlmd` | Database name |
+| `MCP_EXTERNAL_PORT` | `8382` | Host port mapped to the CMF MCP server |
+
+### Common `.env` customizations
+
+**Use a non-standard port (if 80 is taken):**
+```env
+NGINX_HTTP_PORT=8080
+REACT_APP_CMF_API_URL=http://<your-server-ip>:8080
+```
+
+**Store data on a specific volume or NFS mount:**
+```env
+CMF_DATA_DIR=/mnt/nfs/cmf-data
+```
+
+**Expose PostgreSQL externally (uncomment the ports section in docker-compose-server.yml):**
+```env
+POSTGRES_PORT=5432
+```
+
+## Step 3 — Build and start the containers
+
+```bash
+docker compose -f docker-compose-server.yml up -d
+```
+
+This starts five services:
+
+| Service | Role |
+|---------|------|
+| `postgres` | Metadata database (starts first) |
+| `server` | CMF API server (waits for postgres health check) |
+| `ui` | React web interface (waits for server health check) |
+| `tensorboard` | Training metrics visualization |
+| `nginx` | Reverse proxy on ports 80/443 |
+| `mcp` | CMF MCP server on `MCP_EXTERNAL_PORT` |
+
+Check that all containers are healthy:
+
+```bash
+docker compose -f docker-compose-server.yml ps
+```
+
+All services should show `healthy` or `running` within ~60 seconds.
+
+## Step 4 — Verify the web UI
+
+Open a browser and navigate to:
+
+```
+http://<your-server-ip>:80
+```
+
+(or whatever port you set in `NGINX_HTTP_PORT`). The CMF web UI should load and show an empty pipelines list.
+
+Verify the API is responding:
+
+```bash
+curl http://<your-server-ip>:80/apiv1.0/pipelines
+# {"pipelines": []}
+```
+
+## Step 5 — Point cmflib clients at this server
+
+On each client machine that will push/pull metadata, run `cmf init` with the `--cmf-server-url` flag pointing at this server:
+
+```bash
+cmf init local \
+  --path /path/to/artifact-storage \
+  --git-remote-url https://github.com/your-org/your-repo.git \
+  --cmf-server-url http://<your-server-ip>:80
+```
+
+Confirm the client is configured:
+
+```bash
+cmf init show
+# Should show CMF Server URL: http://<your-server-ip>:80
+```
+
+Push a pipeline's metadata to verify end-to-end:
+
+```bash
+cmf metadata push -p my_pipeline
+```
+
+---
+
+## Connecting to an existing CMF Server
+
+If a CMF Server is already running, skip the Docker setup entirely and just point your local CMF client at it.
+
+### Configure the client
+
+```bash
+# Re-initialize CMF with the server URL (keeps existing storage backend config)
+cmf init local \
+  --path /path/to/artifact-storage \
+  --git-remote-url https://github.com/your-org/your-repo.git \
+  --cmf-server-url http://<server-url>:<port>
+```
+
+Or, if CMF is already initialized and you only want to update the server URL, re-run `cmf init` — it will update the configuration in place.
+
+### Verify connectivity
+
+```bash
+cmf init show   # confirm the server URL is set
+cmf pipeline list   # should list pipelines on the remote server (after a pull)
+cmf metadata pull -p my_pipeline   # fetch a pipeline's metadata to confirm access
+```
+
+### What credentials are needed?
+
+The CMF Server does not use username/password authentication by default. Access is controlled at the network level (firewall rules, VPN). If your organization has added an authentication layer in front of the server (e.g. Nginx basic auth or an SSO proxy), ask your administrator for the necessary credentials or token and configure them in your HTTP client or `~/.netrc`.
+
+---
+
+## Stopping and managing the server
+
+```bash
+# Stop containers (data is preserved)
+docker compose -f docker-compose-server.yml stop
+
+# Start again
+docker compose -f docker-compose-server.yml start
+
+# Remove containers (data in CMF_DATA_DIR is preserved)
+docker compose -f docker-compose-server.yml down
+
+# Remove containers AND all data (destructive — backup first)
+docker compose -f docker-compose-server.yml down -v
+rm -rf ./data
+```
+
+## Upgrading the server
+
+After pulling a new version of the CMF repository, rebuild images before restarting:
+
+```bash
+git pull
+docker compose -f docker-compose-server.yml build --no-cache
+docker compose -f docker-compose-server.yml up -d
+```
+
+## Troubleshooting
+
+- **`REACT_APP_CMF_API_URL` not set**: The `server` and `ui` containers will fail to start. This variable is required — set it to the server's actual IP or hostname.
+- **Port 80 already in use**: Change `NGINX_HTTP_PORT` in `.env` and update `REACT_APP_CMF_API_URL` to match.
+- **`postgres` container not healthy**: Check PostgreSQL logs with `docker compose -f docker-compose-server.yml logs postgres`. Usually a permission issue with `CMF_DATA_DIR`.
+- **UI loads but API calls fail**: `REACT_APP_CMF_API_URL` must be reachable from the browser, not just the Docker network. Use the host machine's IP, not `localhost`, when accessing from other machines.
+- **MCP server not reachable**: Check `MCP_EXTERNAL_PORT` in `.env` and confirm it is not blocked by a firewall. Test with `curl http://<server-ip>:<MCP_EXTERNAL_PORT>/health`.
+- **Clients cannot push metadata**: Confirm `cmf init show` shows the correct server URL. Ensure the server port is reachable from the client (`curl http://<server-ip>:80/apiv1.0/pipelines`).
+
+## Further reading
+
+- `docs/setup/index.md` — Full installation guide with Docker prerequisites
+- `docs/cmf_client/index.md` — CMF Client CLI guide and push/pull workflow
+- `docs/ui/index.md` — Web UI reference
+- `docs/mcp/index.md` — CMF MCP server (included in docker-compose-server.yml)

--- a/skills/cmf-server/SKILL.md
+++ b/skills/cmf-server/SKILL.md
@@ -95,6 +95,9 @@ The CMF Server uses network-level access control (no built-in username/password 
 docker compose -f docker-compose-server.yml stop    # stop (data preserved)
 docker compose -f docker-compose-server.yml start   # restart
 docker compose -f docker-compose-server.yml down    # remove containers (data preserved in CMF_DATA_DIR)
+
+# Destructive — backup CMF_DATA_DIR first!
+docker compose -f docker-compose-server.yml down -v && rm -rf ./data
 ```
 
 ## Upgrade
@@ -109,8 +112,10 @@ docker compose -f docker-compose-server.yml up -d
 
 - **`REACT_APP_CMF_API_URL` not set** — required; set to the host's IP/hostname
 - **Port 80 in use** — change `NGINX_HTTP_PORT` and update `REACT_APP_CMF_API_URL` to match
-- **`postgres` not healthy** — check `docker compose ... logs postgres`; often a `CMF_DATA_DIR` permissions issue
-- **UI loads but API calls fail** — use the host IP, not `localhost`, in `REACT_APP_CMF_API_URL`
+- **`postgres` not healthy** — check `docker compose -f docker-compose-server.yml logs postgres`; usually a `CMF_DATA_DIR` permissions issue
+- **UI loads but API calls fail** — use the host IP, not `localhost`, in `REACT_APP_CMF_API_URL`; must be reachable from the browser
+- **MCP server not reachable** — check `MCP_EXTERNAL_PORT` in `.env` and confirm it is not blocked by a firewall; test with `curl http://<server-ip>:<MCP_EXTERNAL_PORT>/health`
+- **Clients cannot push metadata** — confirm `cmf init show` shows the correct server URL; verify with `curl http://<server-ip>:80/apiv1.0/pipelines`
 
 ---
 

--- a/skills/cmf-server/references/env-variables.md
+++ b/skills/cmf-server/references/env-variables.md
@@ -1,0 +1,62 @@
+# CMF Server Environment Variables
+
+All variables are set in the `.env` file in the same directory as `docker-compose-server.yml`.
+
+## Required
+
+| Variable | Example | Purpose |
+|----------|---------|---------|
+| `REACT_APP_CMF_API_URL` | `http://192.168.1.10:80` | URL clients and the browser use to reach the CMF API. Must be reachable from client machines — use the host IP, not `localhost` if accessed remotely. |
+
+## Storage
+
+| Variable | Default | Purpose |
+|----------|---------|---------|
+| `CMF_DATA_DIR` | `./data` | Host path for all persistent data (PostgreSQL files, TensorBoard logs, uploaded artifacts). Use an absolute path for production. |
+
+## Network / Ports
+
+| Variable | Default | Purpose |
+|----------|---------|---------|
+| `NGINX_HTTP_PORT` | `80` | Host port for HTTP |
+| `NGINX_HTTPS_PORT` | `443` | Host port for HTTPS |
+| `MCP_EXTERNAL_PORT` | `8382` | Host port mapped to the CMF MCP server |
+
+## PostgreSQL
+
+| Variable | Default | Purpose |
+|----------|---------|---------|
+| `POSTGRES_USER` | `myuser` | Database username |
+| `POSTGRES_PASSWORD` | `mypassword` | Database password — **change in production** |
+| `POSTGRES_DB` | `mlmd` | Database name |
+| `POSTGRES_HOST` | `postgres` | Service name (internal Docker network) |
+| `POSTGRES_PORT` | `5432` | PostgreSQL port |
+
+## MCP (Multi-server)
+
+| Variable | Default | Purpose |
+|----------|---------|---------|
+| `CMF_BASE_URL` | `http://server:8080` | Primary CMF Server URL (internal) |
+| `CMF2_BASE_URL` | — | Optional second CMF Server |
+| `CMF3_BASE_URL` | — | Optional third CMF Server |
+| `CMF4_BASE_URL` | — | Optional fourth CMF Server |
+
+## Common customizations
+
+**Non-standard HTTP port:**
+```env
+NGINX_HTTP_PORT=8080
+REACT_APP_CMF_API_URL=http://192.168.1.10:8080
+```
+
+**External data volume:**
+```env
+CMF_DATA_DIR=/mnt/nfs/cmf-data
+```
+
+**Multi-environment MCP:**
+```env
+CMF_BASE_URL=http://server:8080
+CMF2_BASE_URL=http://staging-server:8080
+CMF3_BASE_URL=http://prod-server:8080
+```

--- a/skills/cmf-server/sources.md
+++ b/skills/cmf-server/sources.md
@@ -1,0 +1,5 @@
+# Sources
+
+- [Installation & Setup Guide](https://hewlettpackard.github.io/cmf/setup/)
+- `docker-compose-server.yml` — service definitions and environment variable names
+- [CMF Client Guide](https://hewlettpackard.github.io/cmf/cmf_client/)

--- a/skills/cmf-sync/SKILL.md
+++ b/skills/cmf-sync/SKILL.md
@@ -1,0 +1,154 @@
+---
+name: cmf-sync
+description: >
+  Use when pushing or pulling CMF metadata and artifacts between a local environment and
+  a CMF Server or central artifact repository. Covers `cmf metadata push/pull`,
+  `cmf artifact push/pull`, `cmf repo push/pull`, and collaborative team workflows.
+  Assumes CMF has already been initialized with `cmf init`.
+version: 1.0.0
+---
+
+Help the user sync their CMF metadata and artifacts with the central CMF Server and artifact storage. Detect their workflow (solo vs. team, first push vs. update) and guide them to the right commands.
+
+## Prerequisites
+
+- CMF initialized (`cmf init show` shows a valid configuration)
+- At least one pipeline run completed (an `mlmd` file exists)
+- CMF Server running and reachable at the URL shown in `cmf init show`
+
+## Workflow overview
+
+```
+Local environment                CMF Server / Artifact Storage
+─────────────────                ─────────────────────────────
+mlmd (metadata)      ──push──►   CMF Server database
+artifacts (data/models) ──push──►  S3 / MinIO / SSH / local storage
+                     ◄──pull──   (teammates pull metadata + artifacts)
+```
+
+## Push workflow
+
+Run these after every pipeline execution to share your results:
+
+### 1. Push metadata to CMF Server
+
+```bash
+cmf metadata push -p <pipeline_name>
+```
+
+Example:
+
+```bash
+cmf metadata push -p "my_pipeline"
+```
+
+This sends the contents of the local `mlmd` file for the named pipeline to the CMF Server.
+
+### 2. Push artifacts to artifact storage
+
+```bash
+cmf artifact push -p <pipeline_name>
+```
+
+Example:
+
+```bash
+cmf artifact push -p "my_pipeline"
+```
+
+This uploads all artifacts tracked in the pipeline (datasets, models, metrics files) to the configured storage backend (S3, MinIO, SSH, local).
+
+### 3. Push code to Git (optional, if not done automatically)
+
+```bash
+cmf repo push
+```
+
+Pushes the Git repository (code + DVC-tracked artifact pointers) to the configured Git remote.
+
+## Pull workflow
+
+Run these when you want to get a teammate's results or reproduce an experiment:
+
+### 1. Pull metadata from CMF Server
+
+```bash
+cmf metadata pull -p <pipeline_name>
+```
+
+### 2. Pull artifacts from storage
+
+```bash
+cmf artifact pull -p <pipeline_name>
+```
+
+### 3. Pull Git repo (code + DVC pointers)
+
+```bash
+cmf repo pull
+```
+
+## Exporting metadata
+
+Export pipeline metadata to a CSV or JSON file for offline analysis:
+
+```bash
+cmf metadata export -p <pipeline_name> -f metadata_export.json
+```
+
+## End-to-end collaborative workflow
+
+**Developer A (runs experiments and shares results):**
+
+```bash
+# 1. Run the pipeline
+python src/train.py
+
+# 2. Push metadata so the team can see the results
+cmf metadata push -p "my_pipeline"
+
+# 3. Push artifacts so teammates can reproduce
+cmf artifact push -p "my_pipeline"
+```
+
+**Developer B (picks up the shared work):**
+
+```bash
+# 1. Pull the metadata to see pipelines and executions
+cmf metadata pull -p "my_pipeline"
+
+# 2. Pull artifacts needed to continue
+cmf artifact pull -p "my_pipeline"
+
+# 3. Resume work (e.g. run the next pipeline stage)
+python src/evaluate.py
+```
+
+## Quick reference
+
+| Command | Purpose |
+|---------|---------|
+| `cmf metadata push -p <name>` | Upload local mlmd → CMF Server |
+| `cmf metadata pull -p <name>` | Download metadata from CMF Server → local mlmd |
+| `cmf metadata export -p <name> -f <file>` | Export metadata to a file |
+| `cmf artifact push -p <name>` | Upload artifacts → storage backend |
+| `cmf artifact pull -p <name>` | Download artifacts from storage |
+| `cmf repo push` | Push Git repo + DVC pointers |
+| `cmf repo pull` | Pull Git repo + DVC pointers |
+| `cmf pipeline list` | List all local pipelines |
+| `cmf execution list -p <name>` | List executions for a pipeline |
+| `cmf artifact list -p <name>` | List artifacts for a pipeline |
+
+## Troubleshooting
+
+- **`Connection refused` on metadata push**: CMF Server is not running or the URL in `cmf init show` is wrong. Start the server or re-run `cmf init` with the correct `--cmf-server-url`.
+- **`DVC remote not configured`**: Run `cmf init` again with the correct storage backend arguments.
+- **`Pipeline not found`**: The `-p` flag must match the `pipeline_name` used in `Cmf(pipeline_name=...)`. Check with `cmf pipeline list`.
+- **Partial push**: If a push is interrupted, re-run the same command — CMF only uploads missing artifacts.
+- **`mlmd file not found`**: Run at least one instrumented pipeline stage before pushing metadata.
+
+## Further reading
+
+- `docs/cmf_client/index.md` — Full CLI guide with collaborative workflow examples
+- `docs/cmf_client/cmf_client_commands.md` — Complete command reference
+- `docs/setup/index.md` — CMF Server installation instructions

--- a/skills/cmf-sync/SKILL.md
+++ b/skills/cmf-sync/SKILL.md
@@ -2,153 +2,80 @@
 name: cmf-sync
 description: >
   Use when pushing or pulling CMF metadata and artifacts between a local environment and
-  a CMF Server or central artifact repository. Covers `cmf metadata push/pull`,
-  `cmf artifact push/pull`, `cmf repo push/pull`, and collaborative team workflows.
-  Assumes CMF has already been initialized with `cmf init`.
+  a CMF Server or central artifact repository (S3, MinIO, SSH, OSDF, local). Covers
+  `cmf metadata push/pull`, `cmf artifact push/pull`, `cmf repo push/pull`, and
+  collaborative team workflows. Assumes `cmf init` has been run.
 version: 1.0.0
 ---
 
-Help the user sync their CMF metadata and artifacts with the central CMF Server and artifact storage. Detect their workflow (solo vs. team, first push vs. update) and guide them to the right commands.
+Help the user sync their metadata and artifacts. Detect whether they are pushing (sharing results) or pulling (getting a teammate's work).
 
 ## Prerequisites
 
-- CMF initialized (`cmf init show` shows a valid configuration)
+- `cmf init show` returns a valid configuration
 - At least one pipeline run completed (an `mlmd` file exists)
-- CMF Server running and reachable at the URL shown in `cmf init show`
+- CMF Server reachable at the URL in `cmf init show`
 
-## Workflow overview
-
-```
-Local environment                CMF Server / Artifact Storage
-─────────────────                ─────────────────────────────
-mlmd (metadata)      ──push──►   CMF Server database
-artifacts (data/models) ──push──►  S3 / MinIO / SSH / OSDF / local storage
-                     ◄──pull──   (teammates pull metadata + artifacts)
-```
-
-## Push workflow
-
-Run these after every pipeline execution to share your results:
-
-### 1. Push metadata to CMF Server
+## Push workflow (after running your pipeline)
 
 ```bash
-cmf metadata push -p <pipeline_name>
+cmf metadata push -p my_pipeline    # upload mlmd → CMF Server
+cmf artifact push -p my_pipeline    # upload artifacts → S3/MinIO/SSH/OSDF/local
 ```
 
-Example:
+## Pull workflow (get a teammate's results)
 
 ```bash
-cmf metadata push -p "my_pipeline"
+cmf metadata pull -p my_pipeline    # download metadata from CMF Server
+cmf artifact pull -p my_pipeline    # download artifacts from storage backend
 ```
 
-This sends the contents of the local `mlmd` file for the named pipeline to the CMF Server.
-
-### 2. Push artifacts to artifact storage
+## Code + DVC pointer sync
 
 ```bash
-cmf artifact push -p <pipeline_name>
+cmf repo push   # push Git repo + DVC pointers
+cmf repo pull   # pull Git repo + DVC pointers
 ```
 
-Example:
+## Metadata export
 
 ```bash
-cmf artifact push -p "my_pipeline"
+cmf metadata export -p my_pipeline -f export.json
 ```
 
-This uploads all artifacts tracked in the pipeline (datasets, models, metrics files) to the configured storage backend (S3, MinIO, SSH, OSDF, local).
+## End-to-end collaborative example
 
-### 3. Push code to Git (optional, if not done automatically)
-
+**Developer A — share results:**
 ```bash
-cmf repo push
-```
-
-Pushes the Git repository (code + DVC-tracked artifact pointers) to the configured Git remote.
-
-## Pull workflow
-
-Run these when you want to get a teammate's results or reproduce an experiment:
-
-### 1. Pull metadata from CMF Server
-
-```bash
-cmf metadata pull -p <pipeline_name>
-```
-
-### 2. Pull artifacts from storage
-
-```bash
-cmf artifact pull -p <pipeline_name>
-```
-
-### 3. Pull Git repo (code + DVC pointers)
-
-```bash
-cmf repo pull
-```
-
-## Exporting metadata
-
-Export pipeline metadata to a CSV or JSON file for offline analysis:
-
-```bash
-cmf metadata export -p <pipeline_name> -f metadata_export.json
-```
-
-## End-to-end collaborative workflow
-
-**Developer A (runs experiments and shares results):**
-
-```bash
-# 1. Run the pipeline
 python src/train.py
-
-# 2. Push metadata so the team can see the results
-cmf metadata push -p "my_pipeline"
-
-# 3. Push artifacts so teammates can reproduce
-cmf artifact push -p "my_pipeline"
+cmf metadata push -p my_pipeline
+cmf artifact push -p my_pipeline
 ```
 
-**Developer B (picks up the shared work):**
-
+**Developer B — pick up the work:**
 ```bash
-# 1. Pull the metadata to see pipelines and executions
-cmf metadata pull -p "my_pipeline"
-
-# 2. Pull artifacts needed to continue
-cmf artifact pull -p "my_pipeline"
-
-# 3. Resume work (e.g. run the next pipeline stage)
+cmf metadata pull -p my_pipeline
+cmf artifact pull -p my_pipeline
 python src/evaluate.py
 ```
 
-## Quick reference
+## List what's tracked
 
-| Command | Purpose |
-|---------|---------|
-| `cmf metadata push -p <name>` | Upload local mlmd → CMF Server |
-| `cmf metadata pull -p <name>` | Download metadata from CMF Server → local mlmd |
-| `cmf metadata export -p <name> -f <file>` | Export metadata to a file |
-| `cmf artifact push -p <name>` | Upload artifacts → storage backend |
-| `cmf artifact pull -p <name>` | Download artifacts from storage |
-| `cmf repo push` | Push Git repo + DVC pointers |
-| `cmf repo pull` | Pull Git repo + DVC pointers |
-| `cmf pipeline list` | List all local pipelines |
-| `cmf execution list -p <name>` | List executions for a pipeline |
-| `cmf artifact list -p <name>` | List artifacts for a pipeline |
+```bash
+cmf pipeline list
+cmf execution list -p my_pipeline
+cmf artifact list -p my_pipeline
+```
+
+See [references/cli-commands.md](references/cli-commands.md) for the full command flag reference.
 
 ## Troubleshooting
 
-- **`Connection refused` on metadata push**: CMF Server is not running or the URL in `cmf init show` is wrong. Start the server or re-run `cmf init` with the correct `--cmf-server-url`.
-- **`DVC remote not configured`**: Run `cmf init` again with the correct storage backend arguments.
-- **`Pipeline not found`**: The `-p` flag must match the `pipeline_name` used in `Cmf(pipeline_name=...)`. Check with `cmf pipeline list`.
-- **Partial push**: If a push is interrupted, re-run the same command — CMF only uploads missing artifacts.
-- **`mlmd file not found`**: Run at least one instrumented pipeline stage before pushing metadata.
+- **`Connection refused` on push** — CMF Server is not running or the URL in `cmf init show` is wrong
+- **`Pipeline not found`** — the `-p` value must match `pipeline_name` used in `Cmf(...)`. Check with `cmf pipeline list`
+- **Partial push** — re-run the same command; CMF only uploads missing artifacts
+- **`mlmd file not found`** — run at least one instrumented pipeline stage before pushing
 
-## Further reading
+---
 
-- `docs/cmf_client/index.md` — Full CLI guide with collaborative workflow examples
-- `docs/cmf_client/cmf_client_commands.md` — Complete command reference
-- `docs/setup/index.md` — CMF Server installation instructions
+**Docs:** [CMF Client Guide](https://hewlettpackard.github.io/cmf/cmf_client/) · [CLI Command Reference](https://hewlettpackard.github.io/cmf/cmf_client/cmf_client_commands/)

--- a/skills/cmf-sync/SKILL.md
+++ b/skills/cmf-sync/SKILL.md
@@ -72,6 +72,7 @@ See [references/cli-commands.md](references/cli-commands.md) for the full comman
 ## Troubleshooting
 
 - **`Connection refused` on push** — CMF Server is not running or the URL in `cmf init show` is wrong
+- **`DVC remote not configured`** — run `cmf init` again with the correct storage backend arguments
 - **`Pipeline not found`** — the `-p` value must match `pipeline_name` used in `Cmf(...)`. Check with `cmf pipeline list`
 - **Partial push** — re-run the same command; CMF only uploads missing artifacts
 - **`mlmd file not found`** — run at least one instrumented pipeline stage before pushing

--- a/skills/cmf-sync/SKILL.md
+++ b/skills/cmf-sync/SKILL.md
@@ -22,7 +22,7 @@ Help the user sync their CMF metadata and artifacts with the central CMF Server 
 Local environment                CMF Server / Artifact Storage
 ─────────────────                ─────────────────────────────
 mlmd (metadata)      ──push──►   CMF Server database
-artifacts (data/models) ──push──►  S3 / MinIO / SSH / local storage
+artifacts (data/models) ──push──►  S3 / MinIO / SSH / OSDF / local storage
                      ◄──pull──   (teammates pull metadata + artifacts)
 ```
 
@@ -56,7 +56,7 @@ Example:
 cmf artifact push -p "my_pipeline"
 ```
 
-This uploads all artifacts tracked in the pipeline (datasets, models, metrics files) to the configured storage backend (S3, MinIO, SSH, local).
+This uploads all artifacts tracked in the pipeline (datasets, models, metrics files) to the configured storage backend (S3, MinIO, SSH, OSDF, local).
 
 ### 3. Push code to Git (optional, if not done automatically)
 

--- a/skills/cmf-sync/references/cli-commands.md
+++ b/skills/cmf-sync/references/cli-commands.md
@@ -1,0 +1,31 @@
+# CMF Sync CLI Reference
+
+## Metadata commands
+
+| Command | Flags | Purpose |
+|---------|-------|---------|
+| `cmf metadata push` | `-p <pipeline>` | Upload local mlmd → CMF Server |
+| `cmf metadata pull` | `-p <pipeline>` | Download metadata from CMF Server |
+| `cmf metadata export` | `-p <pipeline> -f <file>` | Export metadata to JSON/CSV |
+
+## Artifact commands
+
+| Command | Flags | Purpose |
+|---------|-------|---------|
+| `cmf artifact push` | `-p <pipeline>` | Upload artifacts → storage backend (S3/MinIO/SSH/OSDF/local) |
+| `cmf artifact pull` | `-p <pipeline>` | Download artifacts from storage |
+| `cmf artifact list` | `-p <pipeline>` | List tracked artifacts |
+
+## Repo commands
+
+| Command | Purpose |
+|---------|---------|
+| `cmf repo push` | Push Git repo + DVC artifact pointers |
+| `cmf repo pull` | Pull Git repo + DVC artifact pointers |
+
+## Query commands
+
+| Command | Flags | Purpose |
+|---------|-------|---------|
+| `cmf pipeline list` | — | List all local pipelines |
+| `cmf execution list` | `-p <pipeline>` | List executions for a pipeline |

--- a/skills/cmf-sync/sources.md
+++ b/skills/cmf-sync/sources.md
@@ -1,0 +1,4 @@
+# Sources
+
+- [CMF Client Quick Start](https://hewlettpackard.github.io/cmf/cmf_client/)
+- [CLI Command Reference](https://hewlettpackard.github.io/cmf/cmf_client/cmf_client_commands/)

--- a/skills/cmf/SKILL.md
+++ b/skills/cmf/SKILL.md
@@ -1,0 +1,46 @@
+---
+name: cmf
+description: >
+  Use when working with the Common Metadata Framework (CMF) — initializing CMF in a project,
+  instrumenting ML pipeline code, syncing metadata and artifacts with a CMF Server, querying
+  lineage and artifacts, or setting up the CMF MCP server for AI assistant integration.
+  Routes to the appropriate specialized skill based on the task.
+version: 1.0.0
+user_invocable: true
+argument_hint: "<task>"
+---
+
+Route to the appropriate sub-skill based on the user's task. If the task is ambiguous, ask one clarifying question before routing.
+
+## Quickstart (default path)
+
+If the user wants to add CMF to their project for the first time, or the request is general/unclear, route here:
+
+**[cmf-init](../cmf-init/SKILL.md)** — Install cmflib, configure a storage backend, and create the mlmd metadata store.
+
+## Routing Table
+
+| Task | Sub-skill |
+|------|-----------|
+| Install CMF, configure storage backend (local, S3, MinIO, SSH, OSDF), run `cmf init` | [cmf-init](../cmf-init/SKILL.md) |
+| Add `Cmf()` calls to existing ML pipeline code — contexts, executions, datasets, models, metrics | [cmf-instrument](../cmf-instrument/SKILL.md) |
+| Push or pull metadata and artifacts using the CMF CLI | [cmf-sync](../cmf-sync/SKILL.md) |
+| Query pipeline history, artifact lineage, and execution metadata using `CmfQuery` | [cmf-query](../cmf-query/SKILL.md) |
+| Deploy CMF Server with Docker Compose, or connect to an existing shared server | [cmf-server](../cmf-server/SKILL.md) |
+| Set up the CMF MCP server so an AI assistant can query CMF metadata | [cmf-mcp](../cmf-mcp/SKILL.md) |
+
+## Key Concepts
+
+- **Pipeline** — top-level grouping of stages, identified by `pipeline_name` passed to `Cmf()`
+- **Context** — a stage type (e.g. `"train"`, `"evaluate"`), created with `create_context()`
+- **Execution** — one run of a stage, created with `create_execution()`; hyperparameters go here
+- **Artifact** — dataset, model, or metrics file logged as input or output of an execution
+- **mlmd** — the local SQLite file that stores all metadata; pushed to CMF Server for collaboration
+
+## CMF Documentation
+
+Full documentation is available at the project's `docs/` directory:
+- `docs/index.md` — Getting started and system architecture
+- `docs/cmflib/index.md` — Python API reference
+- `docs/cmf_client/index.md` — CLI command reference
+- `docs/mcp/index.md` — MCP server documentation

--- a/skills/cmf/SKILL.md
+++ b/skills/cmf/SKILL.md
@@ -37,10 +37,6 @@ If the user wants to add CMF to their project for the first time, or the request
 - **Artifact** — dataset, model, or metrics file logged as input or output of an execution
 - **mlmd** — the local SQLite file that stores all metadata; pushed to CMF Server for collaboration
 
-## CMF Documentation
+---
 
-Full documentation is available at the project's `docs/` directory:
-- `docs/index.md` — Getting started and system architecture
-- `docs/cmflib/index.md` — Python API reference
-- `docs/cmf_client/index.md` — CLI command reference
-- `docs/mcp/index.md` — MCP server documentation
+**Docs:** [Getting Started](https://hewlettpackard.github.io/cmf/) · [cmflib API](https://hewlettpackard.github.io/cmf/cmflib/) · [CLI Reference](https://hewlettpackard.github.io/cmf/cmf_client/) · [MCP Server](https://hewlettpackard.github.io/cmf/mcp/)


### PR DESCRIPTION
# Related Issues / Pull Requests

List all related issues and/or pull requests if there are any.

# Description

Add /cmf skills support for coding agents. 
Adds a skills/ directory with six skills installable via
`npx skills add HewlettPackard/cmf --full-depth -y`, compatible
with Claude Code, GitHub Copilot, Cursor, Codex, OpenCode, and
any agentskills.io-compatible coding assistant.

# What changes are proposed in this pull request?

- [ ] Bug fix (non-breaking change which fixes an issue).
- [X] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected; for instance, 
      examples in this repository need to be updated too).
- [X] This change requires a documentation update.

# Checklist:

- [X] My code follows the style guidelines of this project (PEP-8 with Google-style docstrings).
- [X] My code modifies existing public API, or introduces new public API, and I updated or wrote docstrings that
      uses Google-style formatting and any other formatting that is supported by mkdocs and plugins this project
      uses.
- [X] I have commented my code.
- [X] My code requires documentation updates, and I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
