### PR TITLE
Updated message for API error in ui if there is no pipeline listed because cmf-server or postgres is not available

### DIFF
--- a/ui/src/client.js
+++ b/ui/src/client.js
@@ -45,7 +45,7 @@ class FastAPIClient {
         if (error.response?.status >= 500) {
           alert('Server error. Please try again later.');
         } else if (error.request && !error.response) {
-          alert('Unable to connect to server. Please check your connection.');
+          alert('Server connection refused. The backend service may be down. Please restart your Docker container and try again.');
         }
         return Promise.reject(error);
       }


### PR DESCRIPTION
# Related Issues / Pull Requests
Added proper message for API error in GUI if there is no pipeline exists.
This PR is still work in progress so making draft PR.

# Description
This issue occurs when one of the server is down so Need to inform user that, your server is not running please restart your docker container.

# What changes are proposed in this pull request?
This change requires to give user clear message about api error we facing in GUI if there is no pipeline exists.

# Checklist:

This change is required for user understanding while getting API Error.