### PR TITLE
Error regarding if git is not configured.

### DIFF
--- a/cmflib/cmf_commands_wrapper.py
+++ b/cmflib/cmf_commands_wrapper.py
@@ -16,27 +16,12 @@
 
 from typing import Callable, Any
 from cmflib import cli
-from cmflib.cmf_exception_handling import CmfResponse, GitConfigNotSet
-from cmflib.dvc_wrapper import check_git_config
+from cmflib.cmf_exception_handling import CmfResponse
 
 import logging
 
 logger = logging.getLogger(__name__)
 
-
-def _validate_git_config() -> None:
-    """
-    Validates that git user.name and user.email are configured on the system.
-    Raises GitConfigNotSet exception if validation fails.
-    
-    This validation is required before running CMF init commands, as git commits
-    need both user.name and user.email to be set.
-    
-    Raises:
-        GitConfigNotSet: If git user.name or user.email is not configured
-    """
-    if not check_git_config():
-        raise GitConfigNotSet(missing_configs=["user.name", "user.email"])
 
 
 def exception_handler_decorator(
@@ -226,7 +211,6 @@ def _init_local(
     neo4j_uri: str,
 ) -> str:
     """Initialize local repository"""
-    _validate_git_config()
     args = [
             "init",
             "local",
@@ -271,7 +255,6 @@ def _init_minioS3(
     neo4j_uri: str,
 ) -> str:
     """Initialize minioS3 repository"""
-    _validate_git_config()
     args = [
             "init",
             "minioS3",
@@ -320,7 +303,6 @@ def _init_amazonS3(
     neo4j_uri: str,
 ) -> str:
     """Initialize amazonS3 repository"""
-    _validate_git_config()
     args = [
             "init",
             "amazonS3",
@@ -371,7 +353,6 @@ def _init_sshremote(
     neo4j_uri: str,
 ) -> str:
     """Initialize sshremote repository"""
-    _validate_git_config()
     args = [
             "init",
             "sshremote",
@@ -422,7 +403,6 @@ def _init_osdfremote(
     neo4j_uri: str,
 ) -> str:
     """Initialize osdfremote repository"""
-    _validate_git_config()
     args = [
             "init",
             "osdf",

--- a/cmflib/cmf_commands_wrapper.py
+++ b/cmflib/cmf_commands_wrapper.py
@@ -22,8 +22,6 @@ import logging
 
 logger = logging.getLogger(__name__)
 
-
-
 def exception_handler_decorator(
     target_function: Callable[..., Any]
 ) -> Callable[..., Any]:

--- a/cmflib/cmf_commands_wrapper.py
+++ b/cmflib/cmf_commands_wrapper.py
@@ -16,11 +16,28 @@
 
 from typing import Callable, Any
 from cmflib import cli
-from cmflib.cmf_exception_handling import CmfResponse
+from cmflib.cmf_exception_handling import CmfResponse, GitConfigNotSet
+from cmflib.dvc_wrapper import check_git_config
 
 import logging
 
 logger = logging.getLogger(__name__)
+
+
+def _validate_git_config() -> None:
+    """
+    Validates that git user.name and user.email are configured on the system.
+    Raises GitConfigNotSet exception if validation fails.
+    
+    This validation is required before running CMF init commands, as git commits
+    need both user.name and user.email to be set.
+    
+    Raises:
+        GitConfigNotSet: If git user.name or user.email is not configured
+    """
+    if not check_git_config():
+        raise GitConfigNotSet(missing_configs=["user.name", "user.email"])
+
 
 def exception_handler_decorator(
     target_function: Callable[..., Any]
@@ -209,6 +226,7 @@ def _init_local(
     neo4j_uri: str,
 ) -> str:
     """Initialize local repository"""
+    _validate_git_config()
     args = [
             "init",
             "local",
@@ -253,6 +271,7 @@ def _init_minioS3(
     neo4j_uri: str,
 ) -> str:
     """Initialize minioS3 repository"""
+    _validate_git_config()
     args = [
             "init",
             "minioS3",
@@ -301,6 +320,7 @@ def _init_amazonS3(
     neo4j_uri: str,
 ) -> str:
     """Initialize amazonS3 repository"""
+    _validate_git_config()
     args = [
             "init",
             "amazonS3",
@@ -351,6 +371,7 @@ def _init_sshremote(
     neo4j_uri: str,
 ) -> str:
     """Initialize sshremote repository"""
+    _validate_git_config()
     args = [
             "init",
             "sshremote",
@@ -401,6 +422,7 @@ def _init_osdfremote(
     neo4j_uri: str,
 ) -> str:
     """Initialize osdfremote repository"""
+    _validate_git_config()
     args = [
             "init",
             "osdf",

--- a/cmflib/cmf_exception_handling.py
+++ b/cmflib/cmf_exception_handling.py
@@ -365,6 +365,22 @@ class DuplicateArgumentNotAllowed(CmfFailure):
         return f"Error: You can only provide one {self.argument_name} using the {self.argument_flag} flag."
 
 
+class GitConfigNotSet(CmfFailure):
+    """Exception raised when git user.name or user.email is not configured."""
+    def __init__(self, missing_configs: Optional[List[str]] = None, return_code=124):
+        self.missing_configs = missing_configs or []
+        super().__init__(return_code)
+
+    def handle(self):
+        configs_str = ", ".join(self.missing_configs) if self.missing_configs else "user.name and/or user.email"
+        return (
+            f"ERROR: Git configuration is incomplete. Missing: {configs_str}.\n"
+            f"Please configure git before running 'cmf init':\n"
+            f"  git config --global user.name \"Your Name\"\n"
+            f"  git config --global user.email \"your.email@example.com\""
+        )
+
+
 class MissingArgument(CmfFailure):
     def __init__(self, argument_name, return_code=124):
         self.argument_name = argument_name

--- a/cmflib/cmf_exception_handling.py
+++ b/cmflib/cmf_exception_handling.py
@@ -365,22 +365,6 @@ class DuplicateArgumentNotAllowed(CmfFailure):
         return f"Error: You can only provide one {self.argument_name} using the {self.argument_flag} flag."
 
 
-class GitConfigNotSet(CmfFailure):
-    """Exception raised when git user.name or user.email is not configured."""
-    def __init__(self, missing_configs: Optional[List[str]] = None, return_code=124):
-        self.missing_configs = missing_configs or []
-        super().__init__(return_code)
-
-    def handle(self):
-        configs_str = ", ".join(self.missing_configs) if self.missing_configs else "user.name and/or user.email"
-        return (
-            f"ERROR: Git configuration is incomplete. Missing: {configs_str}.\n"
-            f"Please configure git before running 'cmf init':\n"
-            f"  git config --global user.name \"Your Name\"\n"
-            f"  git config --global user.email \"your.email@example.com\""
-        )
-
-
 class MissingArgument(CmfFailure):
     def __init__(self, argument_name, return_code=124):
         self.argument_name = argument_name
@@ -414,3 +398,19 @@ class MsgFailure(CmfFailure):
             return self.msg_list
         else:
             return self.msg_str
+
+
+class GitConfigNotSet(CmfFailure):
+    """Exception raised when git user.name or user.email is not configured."""
+    def __init__(self, missing_configs: Optional[List[str]] = None, return_code=127):
+        self.missing_configs = missing_configs or []
+        super().__init__(return_code)
+
+    def handle(self):
+        configs_str = ", ".join(self.missing_configs) if self.missing_configs else "user.name and/or user.email"
+        return (
+            f"ERROR: Git configuration is incomplete. Missing: {configs_str}.\n"
+            f"Please configure git before running 'cmf init':\n"
+            f"  git config --global user.name \"Your Name\"\n"
+            f"  git config --global user.email \"your.email@example.com\""
+        )

--- a/cmflib/commands/init/amazonS3.py
+++ b/cmflib/commands/init/amazonS3.py
@@ -28,14 +28,19 @@ from cmflib.dvc_wrapper import (
     dvc_add_remote_repo,
     dvc_add_attribute,
     git_modify_remote_url,
+    check_git_config,
 )
 from cmflib.utils.cmf_config import CmfConfig
 from cmflib.utils.helper_functions import is_git_repo
-from cmflib.cmf_exception_handling import Neo4jArgumentNotProvided, CmfInitComplete, CmfInitFailed, DuplicateArgumentNotAllowed, MissingArgument
+from cmflib.cmf_exception_handling import Neo4jArgumentNotProvided, CmfInitComplete, CmfInitFailed, DuplicateArgumentNotAllowed, MissingArgument, GitConfigNotSet
 import sys
 
 class CmdInitAmazonS3(CmdBase):
     def run(self, live):
+        # Validate git configuration before proceeding
+        if not check_git_config():
+            raise GitConfigNotSet(missing_configs=["user.name", "user.email"])
+        
         # User can provide different name for cmf configuration file using CONFIG_FILE environment variable.
         # If CONFIG_FILE is not provided, default file name is .cmfconfig
         cmf_config = os.environ.get("CONFIG_FILE", ".cmfconfig")

--- a/cmflib/commands/init/local.py
+++ b/cmflib/commands/init/local.py
@@ -18,7 +18,7 @@
 import argparse
 import os
 
-from cmflib.cmf_exception_handling import Neo4jArgumentNotProvided, CmfInitComplete, CmfInitFailed
+from cmflib.cmf_exception_handling import Neo4jArgumentNotProvided, CmfInitComplete, CmfInitFailed, GitConfigNotSet
 from cmflib.cli.command import CmdBase
 from cmflib.dvc_wrapper import (
     git_quiet_init,
@@ -28,6 +28,7 @@ from cmflib.dvc_wrapper import (
     dvc_quiet_init,
     dvc_add_remote_repo,
     git_modify_remote_url,
+    check_git_config,
 )
 from cmflib.utils.cmf_config import CmfConfig
 from cmflib.utils.helper_functions import is_git_repo
@@ -35,6 +36,10 @@ from cmflib.cmf_exception_handling import MissingArgument, DuplicateArgumentNotA
 
 class CmdInitLocal(CmdBase):
     def run(self, live):
+        # Validate git configuration before proceeding
+        if not check_git_config():
+            raise GitConfigNotSet(missing_configs=["user.name", "user.email"])
+        
         # User can provide different name for cmf configuration file using CONFIG_FILE environment variable.
         # If CONFIG_FILE is not provided, default file name is .cmfconfig
         cmf_config = os.environ.get("CONFIG_FILE", ".cmfconfig")

--- a/cmflib/commands/init/minioS3.py
+++ b/cmflib/commands/init/minioS3.py
@@ -28,14 +28,19 @@ from cmflib.dvc_wrapper import (
     dvc_add_remote_repo,
     dvc_add_attribute,
     git_modify_remote_url,
+    check_git_config,
 )
 from cmflib.utils.cmf_config import CmfConfig
 from cmflib.utils.helper_functions import is_git_repo
-from cmflib.cmf_exception_handling import Neo4jArgumentNotProvided, CmfInitComplete, CmfInitFailed
+from cmflib.cmf_exception_handling import Neo4jArgumentNotProvided, CmfInitComplete, CmfInitFailed, GitConfigNotSet
 from cmflib.cmf_exception_handling import MissingArgument, DuplicateArgumentNotAllowed
 
 class CmdInitMinioS3(CmdBase):
     def run(self, live):
+        # Validate git configuration before proceeding
+        if not check_git_config():
+            raise GitConfigNotSet(missing_configs=["user.name", "user.email"])
+        
         # User can provide different name for cmf configuration file using CONFIG_FILE environment variable.
         # If CONFIG_FILE is not provided, default file name is .cmfconfig
         cmf_config = os.environ.get("CONFIG_FILE", ".cmfconfig")

--- a/cmflib/commands/init/osdfremote.py
+++ b/cmflib/commands/init/osdfremote.py
@@ -19,7 +19,7 @@
 import argparse
 import os
 
-from cmflib.cmf_exception_handling import CmfInitComplete, CmfInitFailed, Neo4jArgumentNotProvided
+from cmflib.cmf_exception_handling import CmfInitComplete, CmfInitFailed, Neo4jArgumentNotProvided, GitConfigNotSet
 from cmflib.cli.command import CmdBase
 from cmflib.dvc_wrapper import (
     git_quiet_init,
@@ -29,6 +29,7 @@ from cmflib.dvc_wrapper import (
     dvc_quiet_init,
     dvc_add_remote_repo,
     dvc_add_attribute,
+    check_git_config,
 )
 from cmflib.utils.cmf_config import CmfConfig
 from cmflib.utils.helper_functions import is_git_repo
@@ -36,6 +37,10 @@ from cmflib.utils.helper_functions import generate_osdf_token
 
 class CmdInitOSDFRemote(CmdBase):
     def run(self, live):
+        # Validate git configuration before proceeding
+        if not check_git_config():
+            raise GitConfigNotSet(missing_configs=["user.name", "user.email"])
+        
         # User can provide different name for cmf configuration file using CONFIG_FILE environment variable.
         # If CONFIG_FILE is not provided, default file name is .cmfconfig
         cmf_config = os.environ.get("CONFIG_FILE", ".cmfconfig")

--- a/cmflib/commands/init/sshremote.py
+++ b/cmflib/commands/init/sshremote.py
@@ -29,13 +29,18 @@ from cmflib.dvc_wrapper import (
     dvc_quiet_init,
     dvc_add_remote_repo,
     dvc_add_attribute,
+    check_git_config,
 )
 from cmflib.utils.cmf_config import CmfConfig
 from cmflib.utils.helper_functions import is_git_repo
-from cmflib.cmf_exception_handling import Neo4jArgumentNotProvided, CmfInitComplete, CmfInitFailed, DuplicateArgumentNotAllowed, MissingArgument
+from cmflib.cmf_exception_handling import Neo4jArgumentNotProvided, CmfInitComplete, CmfInitFailed, DuplicateArgumentNotAllowed, MissingArgument, GitConfigNotSet
 
 class CmdInitSSHRemote(CmdBase):
     def run(self, live):
+        # Validate git configuration before proceeding
+        if not check_git_config():
+            raise GitConfigNotSet(missing_configs=["user.name", "user.email"])
+        
         # User can provide different name for cmf configuration file using CONFIG_FILE environment variable.
         # If CONFIG_FILE is not provided, default file name is .cmfconfig
         cmf_config = os.environ.get("CONFIG_FILE", ".cmfconfig")

--- a/cmflib/dvc_wrapper.py
+++ b/cmflib/dvc_wrapper.py
@@ -133,6 +133,59 @@ def check_git_repo() -> bool:
     return is_git_repo
 
 
+def check_git_config() -> bool:
+    """
+    Verifies that git user.name and user.email are configured on the system.
+    These are required for git commits to work properly.
+    
+    Returns:
+        bool: True if both user.name and user.email are configured, False otherwise
+    """
+    process: subprocess.Popen
+    git_config_valid = False
+    try:
+        # Check git user.name
+        process = subprocess.Popen(['git', 'config', 'user.name'],
+                                   stdout=subprocess.PIPE,
+                                   stderr=subprocess.PIPE,
+                                   universal_newlines=True)
+        user_name, stderr_name = process.communicate(timeout=60)
+        user_name = user_name.strip()
+        user_name_return_code = process.returncode
+        
+        logger.info(f"[check_git_config] Git user.name check - Return code: {user_name_return_code}, Value: '{user_name}', Stderr: '{stderr_name.strip()}'")
+        
+        # Check git user.email
+        process = subprocess.Popen(['git', 'config', 'user.email'],
+                                   stdout=subprocess.PIPE,
+                                   stderr=subprocess.PIPE,
+                                   universal_newlines=True)
+        user_email, stderr_email = process.communicate(timeout=60)
+        user_email = user_email.strip()
+        user_email_return_code = process.returncode
+        
+        logger.info(f"[check_git_config] Git user.email check - Return code: {user_email_return_code}, Value: '{user_email}', Stderr: '{stderr_email.strip()}'")
+        
+        # Both must be configured (non-empty strings)
+        if user_name and user_email:
+            git_config_valid = True
+            logger.info(f"[check_git_config] Git config VALID - user.name: {user_name}, user.email: {user_email}")
+        else:
+            missing_configs = []
+            if not user_name:
+                missing_configs.append("user.name")
+            if not user_email:
+                missing_configs.append("user.email")
+            logger.warning(f"[check_git_config] Git configuration INCOMPLETE. Missing: {', '.join(missing_configs)}")
+            
+    except Exception as err:
+        logger.error(f"[check_git_config] Exception occurred: {err}, Type: {type(err)}")
+        git_config_valid = False
+    
+    logger.info(f"[check_git_config] Final result: {git_config_valid}")
+    return git_config_valid
+
+
 def git_checkout_new_branch(branch_name: str):
     process: subprocess.Popen
     try:

--- a/cmflib/dvc_wrapper.py
+++ b/cmflib/dvc_wrapper.py
@@ -153,7 +153,7 @@ def check_git_config() -> bool:
         user_name = user_name.strip()
         user_name_return_code = process.returncode
         
-        logger.info(f"[check_git_config] Git user.name check - Return code: {user_name_return_code}, Value: '{user_name}', Stderr: '{stderr_name.strip()}'")
+        logger.debug(f"[check_git_config] Git user.name check - Return code: {user_name_return_code}, Value: '{user_name}', Stderr: '{stderr_name.strip()}'")
         
         # Check git user.email
         process = subprocess.Popen(['git', 'config', 'user.email'],
@@ -164,25 +164,24 @@ def check_git_config() -> bool:
         user_email = user_email.strip()
         user_email_return_code = process.returncode
         
-        logger.info(f"[check_git_config] Git user.email check - Return code: {user_email_return_code}, Value: '{user_email}', Stderr: '{stderr_email.strip()}'")
+        logger.debug(f"[check_git_config] Git user.email check - Return code: {user_email_return_code}, Value: '{user_email}', Stderr: '{stderr_email.strip()}'")
         
         # Both must be configured (non-empty strings)
         if user_name and user_email:
             git_config_valid = True
-            logger.info(f"[check_git_config] Git config VALID - user.name: {user_name}, user.email: {user_email}")
+            logger.debug(f"[check_git_config] Git config VALID - user.name: {user_name}, user.email: {user_email}")
         else:
             missing_configs = []
             if not user_name:
                 missing_configs.append("user.name")
             if not user_email:
                 missing_configs.append("user.email")
-            logger.warning(f"[check_git_config] Git configuration INCOMPLETE. Missing: {', '.join(missing_configs)}")
+            logger.debug(f"[check_git_config] Git configuration INCOMPLETE. Missing: {', '.join(missing_configs)}")
             
     except Exception as err:
         logger.error(f"[check_git_config] Exception occurred: {err}, Type: {type(err)}")
         git_config_valid = False
-    
-    logger.info(f"[check_git_config] Final result: {git_config_valid}")
+        
     return git_config_valid
 
 


### PR DESCRIPTION
# Related Issues / Pull Requests
This PR  added error message while doing cmf init if git configuration is not done on system.

# Description

While running cmf init command the git config  is must else user will not able to proceed.

# What changes are proposed in this pull request?
 Added error message if git username or user email is not configured on system while running cmf init command. If git config is done properly then cmf init will be successful. 

# Checklist:

- [ ] My code follows the style guidelines of this project (PEP-8 with Google-style docstrings).
- [ ] My code modifies existing public API, or introduces new public API, and I updated or wrote docstrings that
      uses Google-style formatting and any other formatting that is supported by mkdocs and plugins this project
      uses.
- [ ] I have commented my code.
- [ ] My code requires documentation updates, and I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.

Adding screenshot for reference 
<img width="1902" height="231" alt="image" src="https://github.com/user-attachments/assets/cb9468cf-0829-418c-9dcc-65e8ec28ac54" />
