### PR TITLE
Added unit test cases for database storage modules

### DIFF
--- a/cmflib/tests/conftest.py
+++ b/cmflib/tests/conftest.py
@@ -1,0 +1,59 @@
+"""
+Pytest configuration and fixtures for CMF tests.
+
+This module sets up mocking for external dependencies like ml_metadata
+that may not be installed in the test environment.
+"""
+
+import sys
+from types import ModuleType
+from unittest.mock import MagicMock
+
+# Create a proper ConnectionConfig class that can be used with isinstance
+class MockConnectionConfig:
+    """Mock ConnectionConfig that behaves like a real config object."""
+    def __init__(self):
+        # Create separate MagicMock objects for each instance
+        # to ensure they don't share state
+        self.sqlite = MagicMock()
+        self.sqlite.filename_uri = None
+        self.sqlite.connection_mode = None
+        self.postgresql = MagicMock()
+        self.postgresql.host = None
+        self.postgresql.port = None
+        self.postgresql.user = None
+        self.postgresql.password = None
+        self.postgresql.dbname = None
+
+# Create mock modules using ModuleType for better control
+ml_metadata_pb2_module = ModuleType('metadata_store_pb2')
+ml_metadata_pb2_module.ConnectionConfig = MockConnectionConfig
+
+# Create the metadata_store sub-module
+metadata_store_submodule = ModuleType('metadata_store')
+metadata_store_submodule.MetadataStore = MagicMock()
+
+# Create the ml_metadata.metadata_store package/module
+ml_metadata_store_module = ModuleType('metadata_store')
+ml_metadata_store_module.metadata_store = metadata_store_submodule
+ml_metadata_store_module.MetadataStore = MagicMock()
+
+ml_metadata_proto_module = ModuleType('proto')
+ml_metadata_proto_module.metadata_store_pb2 = ml_metadata_pb2_module
+
+ml_metadata_module = ModuleType('ml_metadata')
+ml_metadata_module.proto = ml_metadata_proto_module
+ml_metadata_module.metadata_store = ml_metadata_store_module
+
+# Register modules in sys.modules
+sys.modules['ml_metadata'] = ml_metadata_module
+sys.modules['ml_metadata.proto'] = ml_metadata_proto_module
+sys.modules['ml_metadata.proto.metadata_store_pb2'] = ml_metadata_pb2_module
+sys.modules['ml_metadata.metadata_store'] = ml_metadata_store_module
+sys.modules['ml_metadata.metadata_store.metadata_store'] = metadata_store_submodule
+
+
+
+
+
+

--- a/cmflib/tests/store/__init__.py
+++ b/cmflib/tests/store/__init__.py
@@ -1,0 +1,6 @@
+"""
+Database store tests module.
+
+This module contains unit tests for CMF database store implementations
+including abstract store interface, PostgreSQL store, and SQLite store.
+"""

--- a/cmflib/tests/store/test_cmfstore.py
+++ b/cmflib/tests/store/test_cmfstore.py
@@ -1,0 +1,270 @@
+"""
+Unit tests for abstract CmfStore class.
+
+Tests the abstract store interface, initialization, and contract validation.
+"""
+
+import pytest
+from abc import ABC, abstractmethod
+from unittest.mock import Mock, MagicMock, patch
+from ml_metadata.metadata_store import metadata_store
+
+from cmflib.store.cmfstore import CmfStore
+
+
+class ConcreteCmfStore(CmfStore):
+    """Concrete implementation of CmfStore for testing."""
+    
+    def connect(self):
+        """Implement abstract connect method."""
+        return super().connect()
+
+
+class TestCmfStoreInitialization:
+    """Test suite for CmfStore initialization."""
+    
+    def test_init_with_valid_config(self):
+        """Test CmfStore initialization with valid configuration."""
+        config = {"host": "localhost", "port": 5432}
+        store = ConcreteCmfStore(config)
+        
+        assert store.config == config
+        assert isinstance(store, ABC)
+    
+    def test_init_with_empty_config(self):
+        """Test CmfStore initialization with empty configuration."""
+        config = {}
+        store = ConcreteCmfStore(config)
+        
+        assert store.config == {}
+    
+    def test_init_with_none_config(self):
+        """Test CmfStore initialization with None configuration."""
+        config = None
+        store = ConcreteCmfStore(config)
+        
+        assert store.config is None
+    
+    def test_init_with_complex_config(self):
+        """Test CmfStore initialization with complex nested configuration."""
+        config = {
+            "host": "localhost",
+            "port": 5432,
+            "database": {"name": "cmf_db", "version": "1.0"},
+            "credentials": {"user": "admin", "password": "secret"}
+        }
+        store = ConcreteCmfStore(config)
+        
+        assert store.config == config
+        assert store.config["database"]["name"] == "cmf_db"
+        assert store.config["credentials"]["user"] == "admin"
+    
+    def test_init_with_special_characters_in_config(self):
+        """Test CmfStore initialization with special characters in config values."""
+        config = {
+            "password": "p@ss!w0rd#123",
+            "path": "/var/lib/cmf/data",
+            "description": "Test store with ü, ö, ü special chars"
+        }
+        store = ConcreteCmfStore(config)
+        
+        assert store.config == config
+
+
+class TestCmfStoreAbstractMethods:
+    """Test suite for CmfStore abstract methods."""
+    
+    def test_connect_is_abstract(self):
+        """Test that connect method must be implemented by subclasses."""
+        # Verify connect is an abstract method
+        assert hasattr(CmfStore.connect, '__isabstractmethod__')
+        assert CmfStore.connect.__isabstractmethod__
+    
+    def test_cannot_instantiate_abstract_class(self):
+        """Test that CmfStore cannot be instantiated directly."""
+        # Try to instantiate the abstract class directly
+        with pytest.raises(TypeError, match="Can't instantiate abstract class"):
+            CmfStore({"host": "localhost"})
+    
+    @patch('cmflib.store.cmfstore.metadata_store.MetadataStore')
+    def test_connect_returns_metadata_store(self, mock_metadata_store):
+        """Test that connect method returns MetadataStore instance."""
+        mock_store_instance = Mock()
+        mock_metadata_store.return_value = mock_store_instance
+        
+        config = {"host": "localhost"}
+        store = ConcreteCmfStore(config)
+        result = store.connect()
+        
+        # Verify MetadataStore was called with config
+        mock_metadata_store.assert_called_once_with(config)
+        assert result == mock_store_instance
+
+
+class TestCmfStoreSubclassContract:
+    """Test suite for CmfStore subclass contract validation."""
+    
+    def test_subclass_must_implement_connect(self):
+        """Test that subclass must implement connect method."""
+        class IncompleteStore(CmfStore):
+            """Store without connect implementation."""
+            pass
+        
+        # Should not be able to instantiate without implementing abstract method
+        with pytest.raises(TypeError):
+            IncompleteStore({"host": "localhost"})
+    
+    def test_subclass_can_override_init(self):
+        """Test that subclass can override __init__ method."""
+        class CustomStore(CmfStore):
+            def __init__(self, config, extra_param=None):
+                self.extra_param = extra_param
+                super().__init__(config)
+            
+            def connect(self):
+                return super().connect()
+        
+        config = {"host": "localhost"}
+        store = CustomStore(config, extra_param="test_value")
+        
+        assert store.config == config
+        assert store.extra_param == "test_value"
+    
+    @patch('cmflib.store.cmfstore.metadata_store.MetadataStore')
+    def test_subclass_connect_calls_super(self, mock_metadata_store):
+        """Test that subclass connect method can call parent implementation."""
+        mock_store_instance = Mock()
+        mock_metadata_store.return_value = mock_store_instance
+        
+        class CustomStore(CmfStore):
+            def connect(self):
+                # Custom logic before calling parent
+                result = super().connect()
+                # Custom logic after calling parent
+                return result
+        
+        config = {"host": "localhost"}
+        store = CustomStore(config)
+        result = store.connect()
+        
+        assert result == mock_store_instance
+
+
+class TestCmfStoreEdgeCases:
+    """Test suite for CmfStore edge cases."""
+    
+    def test_config_with_none_values(self):
+        """Test CmfStore initialization with None values in config."""
+        config = {"host": None, "port": None, "user": None}
+        store = ConcreteCmfStore(config)
+        
+        assert store.config == config
+        assert store.config["host"] is None
+    
+    def test_config_with_boolean_values(self):
+        """Test CmfStore initialization with boolean config values."""
+        config = {
+            "ssl_enabled": True,
+            "autocommit": False,
+            "debug": True
+        }
+        store = ConcreteCmfStore(config)
+        
+        assert store.config == config
+        assert store.config["ssl_enabled"] is True
+        assert store.config["autocommit"] is False
+    
+    def test_config_with_numeric_values(self):
+        """Test CmfStore initialization with numeric config values."""
+        config = {
+            "port": 5432,
+            "max_connections": 100,
+            "timeout": 30.5,
+            "retries": 0
+        }
+        store = ConcreteCmfStore(config)
+        
+        assert store.config == config
+        assert isinstance(store.config["port"], int)
+        assert isinstance(store.config["timeout"], float)
+    
+    def test_config_with_list_values(self):
+        """Test CmfStore initialization with list values in config."""
+        config = {
+            "hosts": ["localhost", "127.0.0.1", "example.com"],
+            "ports": [5432, 5433, 5434],
+            "empty_list": []
+        }
+        store = ConcreteCmfStore(config)
+        
+        assert store.config == config
+        assert len(store.config["hosts"]) == 3
+        assert store.config["empty_list"] == []
+    
+    def test_config_immutability_concern(self):
+        """Test that config object is stored as reference (not copied)."""
+        config = {"host": "localhost", "port": 5432}
+        store = ConcreteCmfStore(config)
+        
+        # Modify original config
+        config["port"] = 5433
+        
+        # Store should reflect the change (shallow copy behavior)
+        assert store.config["port"] == 5433
+    
+    def test_very_long_config_values(self):
+        """Test CmfStore with very long string config values."""
+        long_password = "p" * 10000
+        very_long_description = "d" * 50000
+        
+        config = {
+            "password": long_password,
+            "description": very_long_description
+        }
+        store = ConcreteCmfStore(config)
+        
+        assert len(store.config["password"]) == 10000
+        assert len(store.config["description"]) == 50000
+    
+    def test_config_with_unicode_characters(self):
+        """Test CmfStore with Unicode characters in config."""
+        config = {
+            "description": "测试中文 тест العربية",
+            "path": "/var/lib/cmf/数据库",
+            "password": "pässwörd"
+        }
+        store = ConcreteCmfStore(config)
+        
+        assert store.config == config
+        assert "测试中文" in store.config["description"]
+
+
+class TestCmfStoreMultipleInstances:
+    """Test suite for multiple CmfStore instances."""
+    
+    def test_multiple_instances_with_different_configs(self):
+        """Test creating multiple CmfStore instances with different configs."""
+        config1 = {"host": "localhost", "port": 5432}
+        config2 = {"host": "remote.example.com", "port": 5432}
+        
+        store1 = ConcreteCmfStore(config1)
+        store2 = ConcreteCmfStore(config2)
+        
+        assert store1.config != store2.config
+        assert store1.config["host"] == "localhost"
+        assert store2.config["host"] == "remote.example.com"
+    
+    def test_multiple_instances_isolation(self):
+        """Test that multiple instances don't interfere with each other."""
+        config1 = {"host": "localhost"}
+        config2 = {"host": "remote"}
+        
+        store1 = ConcreteCmfStore(config1)
+        store2 = ConcreteCmfStore(config2)
+        
+        # Modify config1's dict
+        config1["port"] = 5432
+        
+        # store1 should be affected (reference), but store2 should not
+        assert "port" in store1.config
+        assert "port" not in store2.config

--- a/cmflib/tests/store/test_postgres_store.py
+++ b/cmflib/tests/store/test_postgres_store.py
@@ -1,0 +1,478 @@
+"""
+Unit tests for PostgreSQL store implementation.
+
+Tests PostgreSQL configuration, initialization, and connection management.
+"""
+
+import pytest
+from unittest.mock import Mock, MagicMock, patch, call
+from ml_metadata.proto import metadata_store_pb2 as mlpb
+from ml_metadata.metadata_store import metadata_store
+
+from cmflib.store.postgres import PostgresStore
+
+
+class TestPostgresStoreInitialization:
+    """Test suite for PostgresStore initialization."""
+    
+    @patch('cmflib.store.postgres.metadata_store.MetadataStore')
+    def test_init_with_valid_config(self, mock_metadata_store):
+        """Test PostgresStore initialization with valid configuration."""
+        config = {
+            "host": "localhost",
+            "port": 5432,
+            "user": "postgres",
+            "password": "admin",
+            "dbname": "cmf_db"
+        }
+        
+        store = PostgresStore(config)
+        
+        # Verify config was stored
+        assert store.connection_config is not None
+        assert store.connection_config.postgresql.host == "localhost"
+        assert store.connection_config.postgresql.port == 5432
+        assert store.connection_config.postgresql.user == "postgres"
+        assert store.connection_config.postgresql.password == "admin"
+        assert store.connection_config.postgresql.dbname == "cmf_db"
+    
+    @patch('cmflib.store.postgres.metadata_store.MetadataStore')
+    def test_init_with_different_host(self, mock_metadata_store):
+        """Test initialization with different hostnames."""
+        hosts = [
+            "127.0.0.1",
+            "192.168.1.1",
+            "db.example.com",
+            "postgresql.internal.company.com"
+        ]
+        
+        for host in hosts:
+            config = {
+                "host": host,
+                "port": 5432,
+                "user": "postgres",
+                "password": "admin",
+                "dbname": "cmf_db"
+            }
+            store = PostgresStore(config)
+            assert store.connection_config.postgresql.host == host
+    
+    @patch('cmflib.store.postgres.metadata_store.MetadataStore')
+    def test_init_with_different_ports(self, mock_metadata_store):
+        """Test initialization with different port numbers."""
+        ports = [5432, 5433, 3306, 1234, 65535]
+        
+        for port in ports:
+            config = {
+                "host": "localhost",
+                "port": port,
+                "user": "postgres",
+                "password": "admin",
+                "dbname": "cmf_db"
+            }
+            store = PostgresStore(config)
+            assert store.connection_config.postgresql.port == port
+    
+    @patch('cmflib.store.postgres.metadata_store.MetadataStore')
+    def test_init_with_complex_password(self, mock_metadata_store):
+        """Test initialization with complex password containing special characters."""
+        passwords = [
+            "simple123",
+            "p@ss!word#2024",
+            "pässwörd",
+            "数据库密码",
+            "p\"quote'apostrophe"
+        ]
+        
+        for password in passwords:
+            config = {
+                "host": "localhost",
+                "port": 5432,
+                "user": "postgres",
+                "password": password,
+                "dbname": "cmf_db"
+            }
+            store = PostgresStore(config)
+            assert store.connection_config.postgresql.password == password
+    
+    @patch('cmflib.store.postgres.metadata_store.MetadataStore')
+    def test_init_with_database_names(self, mock_metadata_store):
+        """Test initialization with various database names."""
+        dbnames = [
+            "cmf_db",
+            "cmf",
+            "metadata_store",
+            "db_with_underscores",
+            "db-with-hyphens"
+        ]
+        
+        for dbname in dbnames:
+            config = {
+                "host": "localhost",
+                "port": 5432,
+                "user": "postgres",
+                "password": "admin",
+                "dbname": dbname
+            }
+            store = PostgresStore(config)
+            assert store.connection_config.postgresql.dbname == dbname
+
+
+class TestPostgresStoreConfigValidation:
+    """Test suite for PostgreSQL configuration validation."""
+    
+    def test_init_with_missing_host(self):
+        """Test initialization with missing host key."""
+        config = {
+            "port": 5432,
+            "user": "postgres",
+            "password": "admin",
+            "dbname": "cmf_db"
+        }
+        
+        with pytest.raises(KeyError, match="host"):
+            PostgresStore(config)
+    
+    def test_init_with_missing_port(self):
+        """Test initialization with missing port key."""
+        config = {
+            "host": "localhost",
+            "user": "postgres",
+            "password": "admin",
+            "dbname": "cmf_db"
+        }
+        
+        with pytest.raises(KeyError, match="port"):
+            PostgresStore(config)
+    
+    def test_init_with_missing_user(self):
+        """Test initialization with missing user key."""
+        config = {
+            "host": "localhost",
+            "port": 5432,
+            "password": "admin",
+            "dbname": "cmf_db"
+        }
+        
+        with pytest.raises(KeyError, match="user"):
+            PostgresStore(config)
+    
+    def test_init_with_missing_password(self):
+        """Test initialization with missing password key."""
+        config = {
+            "host": "localhost",
+            "port": 5432,
+            "user": "postgres",
+            "dbname": "cmf_db"
+        }
+        
+        with pytest.raises(KeyError, match="password"):
+            PostgresStore(config)
+    
+    def test_init_with_missing_dbname(self):
+        """Test initialization with missing dbname key."""
+        config = {
+            "host": "localhost",
+            "port": 5432,
+            "user": "postgres",
+            "password": "admin"
+        }
+        
+        with pytest.raises(KeyError, match="dbname"):
+            PostgresStore(config)
+    
+    def test_init_with_empty_config(self):
+        """Test initialization with empty configuration."""
+        config = {}
+        
+        with pytest.raises(KeyError):
+            PostgresStore(config)
+    
+    def test_init_with_none_config_values(self):
+        """Test initialization with None values in config."""
+        config = {
+            "host": None,
+            "port": 5432,
+            "user": "postgres",
+            "password": "admin",
+            "dbname": "cmf_db"
+        }
+        
+        store = PostgresStore(config)
+        assert store.connection_config.postgresql.host is None
+
+
+class TestPostgresStoreConnection:
+    """Test suite for PostgreSQL store connection."""
+    
+    @patch('cmflib.store.postgres.metadata_store.MetadataStore')
+    def test_connect_returns_metadata_store(self, mock_metadata_store):
+        """Test that connect method returns MetadataStore instance."""
+        config = {
+            "host": "localhost",
+            "port": 5432,
+            "user": "postgres",
+            "password": "admin",
+            "dbname": "cmf_db"
+        }
+        
+        mock_store_instance = Mock()
+        mock_metadata_store.return_value = mock_store_instance
+        
+        store = PostgresStore(config)
+        result = store.connect()
+        
+        # Verify MetadataStore was called with connection config
+        mock_metadata_store.assert_called_once()
+        assert result == mock_store_instance
+    
+    @patch('cmflib.store.postgres.metadata_store.MetadataStore')
+    def test_connect_uses_connection_config(self, mock_metadata_store):
+        """Test that connect uses the properly configured connection_config."""
+        config = {
+            "host": "db.example.com",
+            "port": 5433,
+            "user": "admin",
+            "password": "secret",
+            "dbname": "production_db"
+        }
+        
+        mock_store_instance = Mock()
+        mock_metadata_store.return_value = mock_store_instance
+        
+        store = PostgresStore(config)
+        store.connect()
+        
+        # Verify the connection config passed to MetadataStore
+        call_args = mock_metadata_store.call_args
+        passed_config = call_args[0][0]
+        
+        assert passed_config.postgresql.host == "db.example.com"
+        assert passed_config.postgresql.port == 5433
+        assert passed_config.postgresql.user == "admin"
+        assert passed_config.postgresql.password == "secret"
+        assert passed_config.postgresql.dbname == "production_db"
+    
+    @patch('cmflib.store.postgres.metadata_store.MetadataStore')
+    def test_connect_exception_handling(self, mock_metadata_store):
+        """Test connect method when MetadataStore raises exception."""
+        config = {
+            "host": "localhost",
+            "port": 5432,
+            "user": "postgres",
+            "password": "admin",
+            "dbname": "cmf_db"
+        }
+        
+        mock_metadata_store.side_effect = Exception("Connection failed")
+        store = PostgresStore(config)
+        
+        with pytest.raises(Exception, match="Connection failed"):
+            store.connect()
+
+
+class TestPostgresStoreEdgeCases:
+    """Test suite for PostgreSQL store edge cases."""
+    
+    @patch('cmflib.store.postgres.metadata_store.MetadataStore')
+    def test_init_with_empty_string_values(self, mock_metadata_store):
+        """Test initialization with empty string values."""
+        config = {
+            "host": "",
+            "port": 5432,
+            "user": "",
+            "password": "",
+            "dbname": ""
+        }
+        
+        store = PostgresStore(config)
+        assert store.connection_config.postgresql.host == ""
+        assert store.connection_config.postgresql.user == ""
+        assert store.connection_config.postgresql.password == ""
+        assert store.connection_config.postgresql.dbname == ""
+    
+    @patch('cmflib.store.postgres.metadata_store.MetadataStore')
+    def test_init_with_long_strings(self, mock_metadata_store):
+        """Test initialization with very long configuration values."""
+        long_password = "p" * 1000
+        long_dbname = "d" * 500
+        
+        config = {
+            "host": "localhost",
+            "port": 5432,
+            "user": "postgres",
+            "password": long_password,
+            "dbname": long_dbname
+        }
+        
+        store = PostgresStore(config)
+        assert len(store.connection_config.postgresql.password) == 1000
+        assert len(store.connection_config.postgresql.dbname) == 500
+    
+    @patch('cmflib.store.postgres.metadata_store.MetadataStore')
+    def test_init_with_zero_port(self, mock_metadata_store):
+        """Test initialization with port 0."""
+        config = {
+            "host": "localhost",
+            "port": 0,
+            "user": "postgres",
+            "password": "admin",
+            "dbname": "cmf_db"
+        }
+        
+        store = PostgresStore(config)
+        assert store.connection_config.postgresql.port == 0
+    
+    @patch('cmflib.store.postgres.metadata_store.MetadataStore')
+    def test_init_with_negative_port(self, mock_metadata_store):
+        """Test initialization with negative port number."""
+        config = {
+            "host": "localhost",
+            "port": -1,
+            "user": "postgres",
+            "password": "admin",
+            "dbname": "cmf_db"
+        }
+        
+        store = PostgresStore(config)
+        assert store.connection_config.postgresql.port == -1
+    
+    @patch('cmflib.store.postgres.metadata_store.MetadataStore')
+    def test_init_with_ipv6_host(self, mock_metadata_store):
+        """Test initialization with IPv6 host address."""
+        config = {
+            "host": "::1",
+            "port": 5432,
+            "user": "postgres",
+            "password": "admin",
+            "dbname": "cmf_db"
+        }
+        
+        store = PostgresStore(config)
+        assert store.connection_config.postgresql.host == "::1"
+    
+    @patch('cmflib.store.postgres.metadata_store.MetadataStore')
+    def test_init_with_sql_injection_like_strings(self, mock_metadata_store):
+        """Test initialization with SQL injection-like strings in config."""
+        config = {
+            "host": "localhost'; DROP TABLE users; --",
+            "port": 5432,
+            "user": "postgres",
+            "password": "admin' OR '1'='1",
+            "dbname": "cmf_db"
+        }
+        
+        store = PostgresStore(config)
+        # Should store as-is (no validation at this level)
+        assert "DROP TABLE" in store.connection_config.postgresql.host
+        assert "OR" in store.connection_config.postgresql.password
+    
+    @patch('cmflib.store.postgres.metadata_store.MetadataStore')
+    def test_init_with_unicode_in_config(self, mock_metadata_store):
+        """Test initialization with Unicode characters."""
+        config = {
+            "host": "localhost",
+            "port": 5432,
+            "user": "用户",
+            "password": "пароль",
+            "dbname": "قاعدة_البيانات"
+        }
+        
+        store = PostgresStore(config)
+        assert store.connection_config.postgresql.user == "用户"
+        assert store.connection_config.postgresql.password == "пароль"
+        assert store.connection_config.postgresql.dbname == "قاعدة_البيانات"
+
+
+class TestPostgresStoreMultipleInstances:
+    """Test suite for multiple PostgreSQL store instances."""
+    
+    @patch('cmflib.store.postgres.metadata_store.MetadataStore')
+    def test_multiple_stores_independent_configs(self, mock_metadata_store):
+        """Test multiple PostgresStore instances with different configs."""
+        config1 = {
+            "host": "localhost",
+            "port": 5432,
+            "user": "user1",
+            "password": "pass1",
+            "dbname": "db1"
+        }
+        
+        config2 = {
+            "host": "remote.example.com",
+            "port": 5433,
+            "user": "user2",
+            "password": "pass2",
+            "dbname": "db2"
+        }
+        
+        store1 = PostgresStore(config1)
+        store2 = PostgresStore(config2)
+        
+        assert store1.connection_config.postgresql.host == "localhost"
+        assert store2.connection_config.postgresql.host == "remote.example.com"
+        assert store1.connection_config.postgresql.dbname == "db1"
+        assert store2.connection_config.postgresql.dbname == "db2"
+    
+    @patch('cmflib.store.postgres.metadata_store.MetadataStore')
+    def test_store_instances_dont_share_state(self, mock_metadata_store):
+        """Test that multiple store instances don't share state."""
+        config1 = {
+            "host": "localhost",
+            "port": 5432,
+            "user": "postgres",
+            "password": "admin",
+            "dbname": "cmf_db"
+        }
+        
+        config2 = {
+            "host": "remote",
+            "port": 5432,
+            "user": "postgres",
+            "password": "admin",
+            "dbname": "cmf_db"
+        }
+        
+        store1 = PostgresStore(config1)
+        store2 = PostgresStore(config2)
+        
+        # Verify they are independent
+        assert id(store1.connection_config) != id(store2.connection_config)
+        assert store1.connection_config.postgresql.host != store2.connection_config.postgresql.host
+
+
+class TestPostgresStoreInheritance:
+    """Test suite for PostgreSQL store inheritance from CmfStore."""
+    
+    @patch('cmflib.store.postgres.metadata_store.MetadataStore')
+    def test_inherits_from_cmfstore(self, mock_metadata_store):
+        """Test that PostgresStore properly inherits from CmfStore."""
+        config = {
+            "host": "localhost",
+            "port": 5432,
+            "user": "postgres",
+            "password": "admin",
+            "dbname": "cmf_db"
+        }
+        
+        store = PostgresStore(config)
+        
+        # Verify parent config is set
+        assert hasattr(store, 'config')
+        assert isinstance(store.config, mlpb.ConnectionConfig)
+    
+    @patch('cmflib.store.postgres.metadata_store.MetadataStore')
+    def test_config_attribute_set_by_parent(self, mock_metadata_store):
+        """Test that config attribute is properly set through parent class."""
+        config = {
+            "host": "localhost",
+            "port": 5432,
+            "user": "postgres",
+            "password": "admin",
+            "dbname": "cmf_db"
+        }
+        
+        store = PostgresStore(config)
+        
+        # Parent __init__ should set config to connection_config
+        assert store.config == store.connection_config

--- a/cmflib/tests/store/test_sqlite_store.py
+++ b/cmflib/tests/store/test_sqlite_store.py
@@ -1,0 +1,409 @@
+"""
+Unit tests for SQLite store implementation.
+
+Tests SQLite configuration, initialization, file handling, and connection management.
+"""
+
+import pytest
+from unittest.mock import Mock, MagicMock, patch, ANY
+import tempfile
+import os
+
+from ml_metadata.proto import metadata_store_pb2 as mlpb
+from ml_metadata.metadata_store import metadata_store
+
+# Import from actual module (note: sqllite_store has a typo in the filename)
+try:
+    from cmflib.store.sqllite_store import SqlliteStore
+except ImportError:
+    from cmflib.store.sqlite_store import SqlliteStore
+
+
+class TestSqliteStoreInitialization:
+    """Test suite for SQLite store initialization."""
+    
+    @patch('cmflib.store.sqllite_store.metadata_store.MetadataStore')
+    def test_init_with_valid_config(self, mock_metadata_store):
+        """Test SqlliteStore initialization with valid configuration."""
+        config = {"filename": "/path/to/database.db"}
+        store = SqlliteStore(config)
+        
+        # Verify config was stored
+        assert store.connection_config is not None
+        assert store.connection_config.sqlite.filename_uri == "/path/to/database.db"
+        assert store.connection_config.sqlite.connection_mode == 3  # READWRITE_OPENCREATE
+    
+    @patch('cmflib.store.sqllite_store.metadata_store.MetadataStore')
+    def test_init_with_relative_path(self, mock_metadata_store):
+        """Test initialization with relative file path."""
+        config = {"filename": "cmf.db"}
+        store = SqlliteStore(config)
+        
+        assert store.connection_config.sqlite.filename_uri == "cmf.db"
+    
+    @patch('cmflib.store.sqllite_store.metadata_store.MetadataStore')
+    def test_init_with_absolute_path(self, mock_metadata_store):
+        """Test initialization with absolute file path."""
+        config = {"filename": "/var/lib/cmf/metadata.db"}
+        store = SqlliteStore(config)
+        
+        assert store.connection_config.sqlite.filename_uri == "/var/lib/cmf/metadata.db"
+    
+    @patch('cmflib.store.sqllite_store.metadata_store.MetadataStore')
+    def test_init_with_windows_path(self, mock_metadata_store):
+        """Test initialization with Windows-style path."""
+        config = {"filename": "C:\\Users\\cmf\\metadata.db"}
+        store = SqlliteStore(config)
+        
+        assert store.connection_config.sqlite.filename_uri == "C:\\Users\\cmf\\metadata.db"
+    
+    @patch('cmflib.store.sqllite_store.metadata_store.MetadataStore')
+    def test_init_with_different_filenames(self, mock_metadata_store):
+        """Test initialization with various database filenames."""
+        filenames = [
+            "cmf.db",
+            "metadata.sqlite",
+            "metadata.sqlite3",
+            "db_2024.db",
+            "cmf_prod_db.sqlite"
+        ]
+        
+        for filename in filenames:
+            config = {"filename": filename}
+            store = SqlliteStore(config)
+            assert store.connection_config.sqlite.filename_uri == filename
+    
+    @patch('cmflib.store.sqllite_store.metadata_store.MetadataStore')
+    def test_connection_mode_is_set_to_readwrite_opencreate(self, mock_metadata_store):
+        """Test that connection mode is always set to READWRITE_OPENCREATE (3)."""
+        config = {"filename": "test.db"}
+        store = SqlliteStore(config)
+        
+        # Connection mode should always be 3 (READWRITE_OPENCREATE)
+        assert store.connection_config.sqlite.connection_mode == 3
+
+
+class TestSqliteStoreConfigValidation:
+    """Test suite for SQLite configuration validation."""
+    
+    def test_init_with_missing_filename(self):
+        """Test initialization with missing filename key."""
+        config = {}
+        
+        with pytest.raises(KeyError, match="filename"):
+            SqlliteStore(config)
+    
+    def test_init_with_none_filename(self):
+        """Test initialization with None filename."""
+        config = {"filename": None}
+        store = SqlliteStore(config)
+        
+        assert store.connection_config.sqlite.filename_uri is None
+    
+    def test_init_with_empty_filename(self):
+        """Test initialization with empty filename string."""
+        config = {"filename": ""}
+        store = SqlliteStore(config)
+        
+        assert store.connection_config.sqlite.filename_uri == ""
+    
+    def test_init_with_multiple_keys_ignores_extra(self):
+        """Test that extra keys in config are ignored."""
+        config = {
+            "filename": "test.db",
+            "extra_key": "extra_value",
+            "another_key": 123
+        }
+        store = SqlliteStore(config)
+        
+        # Should only use filename key
+        assert store.connection_config.sqlite.filename_uri == "test.db"
+
+
+class TestSqliteStoreConnection:
+    """Test suite for SQLite store connection."""
+    
+    @patch('cmflib.store.sqllite_store.metadata_store.MetadataStore')
+    def test_connect_returns_metadata_store(self, mock_metadata_store):
+        """Test that connect method returns MetadataStore instance."""
+        config = {"filename": "test.db"}
+        mock_store_instance = Mock()
+        mock_metadata_store.return_value = mock_store_instance
+        
+        store = SqlliteStore(config)
+        result = store.connect()
+        
+        # Verify MetadataStore was called
+        mock_metadata_store.assert_called_once()
+        assert result == mock_store_instance
+    
+    @patch('cmflib.store.sqllite_store.metadata_store.MetadataStore')
+    def test_connect_uses_connection_config(self, mock_metadata_store):
+        """Test that connect uses the properly configured connection_config."""
+        config = {"filename": "/var/lib/cmf/metadata.db"}
+        mock_store_instance = Mock()
+        mock_metadata_store.return_value = mock_store_instance
+        
+        store = SqlliteStore(config)
+        store.connect()
+        
+        # Verify the connection config passed to MetadataStore
+        call_args = mock_metadata_store.call_args
+        passed_config = call_args[0][0]
+        
+        assert passed_config.sqlite.filename_uri == "/var/lib/cmf/metadata.db"
+        assert passed_config.sqlite.connection_mode == 3
+    
+    @patch('cmflib.store.sqllite_store.metadata_store.MetadataStore')
+    def test_connect_exception_handling(self, mock_metadata_store):
+        """Test connect method when MetadataStore raises exception."""
+        config = {"filename": "test.db"}
+        mock_metadata_store.side_effect = Exception("Database connection failed")
+        store = SqlliteStore(config)
+        
+        with pytest.raises(Exception, match="Database connection failed"):
+            store.connect()
+    
+    @patch('cmflib.store.sqllite_store.metadata_store.MetadataStore')
+    def test_connect_with_readonly_path(self, mock_metadata_store):
+        """Test connect with read-only file path."""
+        config = {"filename": "/usr/share/cmf/metadata.db"}
+        mock_store_instance = Mock()
+        mock_metadata_store.return_value = mock_store_instance
+        
+        store = SqlliteStore(config)
+        store.connect()
+        
+        # Should still try to connect even with read-only path
+        mock_metadata_store.assert_called_once()
+
+
+class TestSqliteStoreEdgeCases:
+    """Test suite for SQLite store edge cases."""
+    
+    @patch('cmflib.store.sqllite_store.metadata_store.MetadataStore')
+    def test_init_with_very_long_path(self, mock_metadata_store):
+        """Test initialization with very long file path."""
+        long_path = "/path/" + "subdir/" * 100 + "database.db"
+        config = {"filename": long_path}
+        store = SqlliteStore(config)
+        
+        assert store.connection_config.sqlite.filename_uri == long_path
+        assert len(store.connection_config.sqlite.filename_uri) > 500
+    
+    @patch('cmflib.store.sqllite_store.metadata_store.MetadataStore')
+    def test_init_with_special_characters_in_path(self, mock_metadata_store):
+        """Test initialization with special characters in file path."""
+        paths = [
+            "/path/with spaces/database.db",
+            "/path/with-dashes/db.db",
+            "/path/with_underscores/database.db",
+            "/path/with.dots/database.db",
+            "/path/with(parens)/database.db",
+            "/path/with[brackets]/database.db"
+        ]
+        
+        for path in paths:
+            config = {"filename": path}
+            store = SqlliteStore(config)
+            assert store.connection_config.sqlite.filename_uri == path
+    
+    @patch('cmflib.store.sqllite_store.metadata_store.MetadataStore')
+    def test_init_with_unicode_in_path(self, mock_metadata_store):
+        """Test initialization with Unicode characters in file path."""
+        paths = [
+            "/path/to/数据库/metadata.db",
+            "/path/to/база_данных.db",
+            "/path/to/قاعدة_البيانات.db",
+            "/path/with_émojis/🗄️.db"
+        ]
+        
+        for path in paths:
+            config = {"filename": path}
+            store = SqlliteStore(config)
+            assert store.connection_config.sqlite.filename_uri == path
+    
+    @patch('cmflib.store.sqllite_store.metadata_store.MetadataStore')
+    def test_init_with_sql_injection_like_filename(self, mock_metadata_store):
+        """Test initialization with SQL injection-like filename."""
+        config = {"filename": "'; DROP TABLE metadata; --.db"}
+        store = SqlliteStore(config)
+        
+        # Should store as-is (URI path, not SQL)
+        assert store.connection_config.sqlite.filename_uri == "'; DROP TABLE metadata; --.db"
+    
+    @patch('cmflib.store.sqllite_store.metadata_store.MetadataStore')
+    def test_init_with_uri_format_filename(self, mock_metadata_store):
+        """Test initialization with URI-format filename."""
+        config = {"filename": "file:///path/to/database.db?mode=rw"}
+        store = SqlliteStore(config)
+        
+        assert store.connection_config.sqlite.filename_uri == "file:///path/to/database.db?mode=rw"
+    
+    @patch('cmflib.store.sqllite_store.metadata_store.MetadataStore')
+    def test_init_with_memory_database(self, mock_metadata_store):
+        """Test initialization with in-memory SQLite database."""
+        config = {"filename": ":memory:"}
+        store = SqlliteStore(config)
+        
+        assert store.connection_config.sqlite.filename_uri == ":memory:"
+    
+    @patch('cmflib.store.sqllite_store.metadata_store.MetadataStore')
+    def test_init_with_temporary_database(self, mock_metadata_store):
+        """Test initialization with temporary SQLite database."""
+        config = {"filename": ""}
+        store = SqlliteStore(config)
+        
+        # Empty string typically means temporary database
+        assert store.connection_config.sqlite.filename_uri == ""
+    
+    @patch('cmflib.store.sqllite_store.metadata_store.MetadataStore')
+    def test_connection_mode_never_changes(self, mock_metadata_store):
+        """Test that connection mode is always 3 regardless of config."""
+        configs = [
+            {"filename": "test.db"},
+            {"filename": "/path/to/db.sqlite"},
+            {"filename": ":memory:"},
+            {"filename": ""}
+        ]
+        
+        for config in configs:
+            store = SqlliteStore(config)
+            assert store.connection_config.sqlite.connection_mode == 3
+
+
+class TestSqliteStoreMultipleInstances:
+    """Test suite for multiple SQLite store instances."""
+    
+    @patch('cmflib.store.sqllite_store.metadata_store.MetadataStore')
+    def test_multiple_stores_independent_configs(self, mock_metadata_store):
+        """Test multiple SqlliteStore instances with different configs."""
+        config1 = {"filename": "database1.db"}
+        config2 = {"filename": "/var/lib/cmf/database2.db"}
+        config3 = {"filename": ":memory:"}
+        
+        store1 = SqlliteStore(config1)
+        store2 = SqlliteStore(config2)
+        store3 = SqlliteStore(config3)
+        
+        assert store1.connection_config.sqlite.filename_uri == "database1.db"
+        assert store2.connection_config.sqlite.filename_uri == "/var/lib/cmf/database2.db"
+        assert store3.connection_config.sqlite.filename_uri == ":memory:"
+    
+    @patch('cmflib.store.sqllite_store.metadata_store.MetadataStore')
+    def test_store_instances_dont_share_state(self, mock_metadata_store):
+        """Test that multiple store instances don't share state."""
+        config1 = {"filename": "db1.sqlite"}
+        config2 = {"filename": "db2.sqlite"}
+        
+        store1 = SqlliteStore(config1)
+        store2 = SqlliteStore(config2)
+        
+        # Verify they are independent
+        assert id(store1.connection_config) != id(store2.connection_config)
+        assert store1.connection_config.sqlite.filename_uri != store2.connection_config.sqlite.filename_uri
+
+
+class TestSqliteStoreInheritance:
+    """Test suite for SQLite store inheritance from CmfStore."""
+    
+    @patch('cmflib.store.sqllite_store.metadata_store.MetadataStore')
+    def test_inherits_from_cmfstore(self, mock_metadata_store):
+        """Test that SqlliteStore properly inherits from CmfStore."""
+        config = {"filename": "test.db"}
+        store = SqlliteStore(config)
+        
+        # Verify parent config is set
+        assert hasattr(store, 'config')
+        assert isinstance(store.config, mlpb.ConnectionConfig)
+    
+    @patch('cmflib.store.sqllite_store.metadata_store.MetadataStore')
+    def test_config_attribute_set_by_parent(self, mock_metadata_store):
+        """Test that config attribute is properly set through parent class."""
+        config = {"filename": "test.db"}
+        store = SqlliteStore(config)
+        
+        # Parent __init__ should set config to connection_config
+        assert store.config == store.connection_config
+    
+    @patch('cmflib.store.sqllite_store.metadata_store.MetadataStore')
+    def test_has_connect_method(self, mock_metadata_store):
+        """Test that SqlliteStore has connect method from parent."""
+        config = {"filename": "test.db"}
+        store = SqlliteStore(config)
+        
+        assert hasattr(store, 'connect')
+        assert callable(store.connect)
+
+
+class TestSqliteStorePathHandling:
+    """Test suite for SQLite file path handling."""
+    
+    @patch('cmflib.store.sqllite_store.metadata_store.MetadataStore')
+    def test_path_with_trailing_slash(self, mock_metadata_store):
+        """Test path with trailing slash."""
+        config = {"filename": "/var/lib/cmf/"}
+        store = SqlliteStore(config)
+        
+        assert store.connection_config.sqlite.filename_uri == "/var/lib/cmf/"
+    
+    @patch('cmflib.store.sqllite_store.metadata_store.MetadataStore')
+    def test_path_with_dot_notation(self, mock_metadata_store):
+        """Test path with dot notation (relative paths)."""
+        config = {"filename": "./metadata.db"}
+        store = SqlliteStore(config)
+        
+        assert store.connection_config.sqlite.filename_uri == "./metadata.db"
+    
+    @patch('cmflib.store.sqllite_store.metadata_store.MetadataStore')
+    def test_path_with_double_dot_notation(self, mock_metadata_store):
+        """Test path with double dot notation (parent directory)."""
+        config = {"filename": "../data/metadata.db"}
+        store = SqlliteStore(config)
+        
+        assert store.connection_config.sqlite.filename_uri == "../data/metadata.db"
+    
+    @patch('cmflib.store.sqllite_store.metadata_store.MetadataStore')
+    def test_path_with_symlink_like_notation(self, mock_metadata_store):
+        """Test path that could be a symlink."""
+        config = {"filename": "/etc/cmf/links/database.db"}
+        store = SqlliteStore(config)
+        
+        assert store.connection_config.sqlite.filename_uri == "/etc/cmf/links/database.db"
+    
+    @patch('cmflib.store.sqllite_store.metadata_store.MetadataStore')
+    def test_home_directory_expansion_not_performed(self, mock_metadata_store):
+        """Test that tilde (~) in path is stored as-is (not expanded)."""
+        config = {"filename": "~/cmf/metadata.db"}
+        store = SqlliteStore(config)
+        
+        # Tilde should be stored as-is (no expansion at this level)
+        assert store.connection_config.sqlite.filename_uri == "~/cmf/metadata.db"
+
+
+class TestSqliteStoreConnectionModeDetails:
+    """Test suite for SQLite connection mode specifics."""
+    
+    @patch('cmflib.store.sqllite_store.metadata_store.MetadataStore')
+    def test_readwrite_opencreate_mode_value(self, mock_metadata_store):
+        """Test that connection mode is specifically READWRITE_OPENCREATE (3)."""
+        config = {"filename": "test.db"}
+        store = SqlliteStore(config)
+        
+        # READWRITE_OPENCREATE = 3
+        # This mode allows:
+        # - Reading from database
+        # - Writing to database
+        # - Creating database if it doesn't exist
+        assert store.connection_config.sqlite.connection_mode == 3
+    
+    @patch('cmflib.store.sqllite_store.metadata_store.MetadataStore')
+    def test_connection_mode_consistent_across_instances(self, mock_metadata_store):
+        """Test that connection mode is consistent across all instances."""
+        stores = [
+            SqlliteStore({"filename": f"db{i}.sqlite"})
+            for i in range(5)
+        ]
+        
+        for store in stores:
+            assert store.connection_config.sqlite.connection_mode == 3


### PR DESCRIPTION
# Related Issues / Pull Requests

Added unit test cases for database storage modules in our codebase.
1.cmf store
2.postgres store
3.sqlite store

# Description

Unit test cases for database storage modules in our codebase.
1.cmf store
2.postgres store
3.sqlite store


# What changes are proposed in this pull request?


- [ ] New feature (non-breaking change which adds functionality).

# Checklist:

- [ ] My code follows the style guidelines of this project (PEP-8 with Google-style docstrings).
- [ ] My code modifies existing public API, or introduces new public API, and I updated or wrote docstrings that
      uses Google-style formatting and any other formatting that is supported by mkdocs and plugins this project
      uses.
- [ ] I have commented my code.
- [ ] My code requires documentation updates, and I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
