### PR TITLE
feat(server): enable HTTPS with self-signed TLS certificate

### DIFF
--- a/docker-compose-server.yml
+++ b/docker-compose-server.yml
@@ -150,6 +150,7 @@ services:
       - ${NGINX_HTTPS_PORT:-443}:443
     volumes:
       - ./nginx.conf:/etc/nginx/nginx.conf:ro
+      - ${CMF_DATA_DIR:-./data}/nginx-certs:/etc/nginx/certs:ro
     networks:
       - cmf-network
     depends_on:

--- a/docker-compose-server.yml
+++ b/docker-compose-server.yml
@@ -151,6 +151,7 @@ services:
     volumes:
       - ./nginx.conf:/etc/nginx/nginx.conf:ro
       - ${CMF_DATA_DIR:-./data}/nginx-certs:/etc/nginx/certs:ro
+      - ./scripts/nginx-autogen-cert.sh:/docker-entrypoint.d/40-autogen-cert.sh:ro
     networks:
       - cmf-network
     depends_on:

--- a/docs/setup/index.md
+++ b/docs/setup/index.md
@@ -116,7 +116,12 @@ REACT_APP_CMF_API_URL=http://your-server-ip:80
 
 > 📝 **Note:** 
 > - `CMF_DATA_DIR` controls where all data (PostgreSQL, TensorBoard logs, etc.) is stored. Use an absolute path for better control.
-> - `REACT_APP_CMF_API_URL` should point to your server's accessible address.
+> - `REACT_APP_CMF_API_URL` is the URL the **browser** uses to fetch API calls from the UI. Its scheme (`http`/`https`) and port **must match how you access the UI** — otherwise the browser blocks API calls as mixed content. Choose one:
+>
+>     | Access UI over... | `REACT_APP_CMF_API_URL` |
+>     |---|---|
+>     | HTTP (default, no cert warnings) | `http://your-server-ip:<NGINX_HTTP_PORT>` |
+>     | HTTPS (self-signed cert; browser warns) | `https://your-server-ip:<NGINX_HTTPS_PORT>` |
 
 **Step 4: Generate the TLS Certificate (recommended)**
 
@@ -162,15 +167,14 @@ This command starts all services:
 
 #### Accessing the CMF UI
 
-Once the containers are successfully started, the CMF UI will be available at the URL specified in your `.env` file:
+Once the containers are successfully started, open the CMF UI in a browser at the URL that matches your `REACT_APP_CMF_API_URL` scheme (see Step 3):
 
-```
-http://your-server-ip:80
-```
+- **HTTP** (no cert warnings): `http://your-server-ip:<NGINX_HTTP_PORT>` (default `80`)
+- **HTTPS** (self-signed cert; browser will warn): `https://your-server-ip:<NGINX_HTTPS_PORT>` (default `443`)
 
-Replace `your-server-ip` with the actual IP address or hostname configured in the `REACT_APP_CMF_API_URL` environment variable. The UI is also reachable over HTTPS at `https://your-server-ip:<NGINX_HTTPS_PORT>` (default `443`).
+> ⚠️ **Important:** The scheme you use to open the UI **must match** the scheme in `REACT_APP_CMF_API_URL`. Loading the UI over `https://` while the API URL is `http://` causes the browser to block API calls as mixed content, and the UI will show "Server connection refused".
 
-> 📝 **Note:** Ensure that port 80 (or your configured `NGINX_HTTP_PORT`) and port 443 (or your configured `NGINX_HTTPS_PORT`) are accessible and not blocked by firewall rules.
+> 📝 **Note:** Ensure that the ports you configured (`NGINX_HTTP_PORT` and `NGINX_HTTPS_PORT`) are accessible and not blocked by firewall rules.
 
 **Step 6: Stop the Containers**
 

--- a/docs/setup/index.md
+++ b/docs/setup/index.md
@@ -156,6 +156,27 @@ Replace `your-server-ip` with the actual IP address or hostname configured in th
 docker compose -f docker-compose-server.yml stop
 ```
 
+#### Enabling HTTPS
+
+The nginx service also listens on `NGINX_HTTPS_PORT` (container port 443) when
+a TLS certificate is present. To generate a self-signed certificate:
+
+```bash
+scripts/generate-self-signed-cert.sh
+```
+
+This writes `cmf.crt` and `cmf.key` into `$CMF_DATA_DIR/nginx-certs/`, which
+the `nginx` service mounts read-only at `/etc/nginx/certs/`. After generating
+the certificate, (re)start the stack and access CMF over HTTPS:
+
+```
+https://your-server-ip:443
+```
+
+> 📝 **Note:** Browsers will warn about the self-signed certificate. To use
+> your own certificate, copy your `cmf.crt` and `cmf.key` into
+> `$CMF_DATA_DIR/nginx-certs/` instead of running the script.
+
 #### Important Notes
 
 > 💡 **Rebuild Required:** 

--- a/docs/setup/index.md
+++ b/docs/setup/index.md
@@ -168,7 +168,7 @@ Once the containers are successfully started, the CMF UI will be available at th
 http://your-server-ip:80
 ```
 
-Replace `your-server-ip` with the actual IP address or hostname configured in the `REACT_APP_CMF_API_URL` environment variable. The UI is also reachable over HTTPS at `https://your-server-ip:443`.
+Replace `your-server-ip` with the actual IP address or hostname configured in the `REACT_APP_CMF_API_URL` environment variable. The UI is also reachable over HTTPS at `https://your-server-ip:<NGINX_HTTPS_PORT>` (default `443`).
 
 > 📝 **Note:** Ensure that port 80 (or your configured `NGINX_HTTP_PORT`) and port 443 (or your configured `NGINX_HTTPS_PORT`) are accessible and not blocked by firewall rules.
 

--- a/docs/setup/index.md
+++ b/docs/setup/index.md
@@ -118,24 +118,27 @@ REACT_APP_CMF_API_URL=http://your-server-ip:80
 > - `CMF_DATA_DIR` controls where all data (PostgreSQL, TensorBoard logs, etc.) is stored. Use an absolute path for better control.
 > - `REACT_APP_CMF_API_URL` should point to your server's accessible address.
 
-**Step 4: Generate the TLS Certificate (required)**
+**Step 4: Generate the TLS Certificate (recommended)**
 
 The nginx service listens on both `NGINX_HTTP_PORT` (HTTP) and
-`NGINX_HTTPS_PORT` (HTTPS) and **requires** a TLS certificate to start. If the
-certificate files are missing, the `nginx` container will fail to start.
-
-Generate a self-signed certificate with the included helper:
+`NGINX_HTTPS_PORT` (HTTPS). The `nginx` container ships with an entrypoint
+script that **auto-generates a throwaway self-signed certificate on startup if
+none is found**, so HTTPS works out of the box (the cert is regenerated on each
+start). For a **stable** certificate that persists across restarts, generate
+one with the included helper:
 
 ```bash
 scripts/generate-self-signed-cert.sh
 ```
 
 This writes `cmf.crt` and `cmf.key` into `$CMF_DATA_DIR/nginx-certs/`, which
-the `nginx` service mounts read-only at `/etc/nginx/certs/`.
+the `nginx` service mounts read-only at `/etc/nginx/certs/` and copies into
+place on startup.
 
-> 📝 **Note:** Browsers will warn about the self-signed certificate. To use
-> your own certificate, copy your `cmf.crt` and `cmf.key` into
-> `$CMF_DATA_DIR/nginx-certs/` instead of running the script.
+> 📝 **Note:** Browsers will warn about the self-signed certificate (whether
+> auto-generated or stable). To use your own certificate, copy your `cmf.crt`
+> and `cmf.key` into `$CMF_DATA_DIR/nginx-certs/` instead of running the
+> script.
 
 **Step 5: Start the Containers**
 

--- a/docs/setup/index.md
+++ b/docs/setup/index.md
@@ -118,7 +118,26 @@ REACT_APP_CMF_API_URL=http://your-server-ip:80
 > - `CMF_DATA_DIR` controls where all data (PostgreSQL, TensorBoard logs, etc.) is stored. Use an absolute path for better control.
 > - `REACT_APP_CMF_API_URL` should point to your server's accessible address.
 
-**Step 4: Start the Containers**
+**Step 4: Generate the TLS Certificate (required)**
+
+The nginx service listens on both `NGINX_HTTP_PORT` (HTTP) and
+`NGINX_HTTPS_PORT` (HTTPS) and **requires** a TLS certificate to start. If the
+certificate files are missing, the `nginx` container will fail to start.
+
+Generate a self-signed certificate with the included helper:
+
+```bash
+scripts/generate-self-signed-cert.sh
+```
+
+This writes `cmf.crt` and `cmf.key` into `$CMF_DATA_DIR/nginx-certs/`, which
+the `nginx` service mounts read-only at `/etc/nginx/certs/`.
+
+> 📝 **Note:** Browsers will warn about the self-signed certificate. To use
+> your own certificate, copy your `cmf.crt` and `cmf.key` into
+> `$CMF_DATA_DIR/nginx-certs/` instead of running the script.
+
+**Step 5: Start the Containers**
 
 > 💡 **Recommended Approach:** Using `docker compose` starts the `CMF Server`, PostgreSQL database, and `CMF UI` together.
 > 
@@ -136,7 +155,7 @@ This command starts all services:
 - **CMF Server**: API server for metadata management
 - **UI**: Web interface for visualization
 - **TensorBoard**: For viewing ML training metrics
-- **Nginx**: Reverse proxy serving all components
+- **Nginx**: Reverse proxy serving all components over HTTP and HTTPS
 
 #### Accessing the CMF UI
 
@@ -146,36 +165,15 @@ Once the containers are successfully started, the CMF UI will be available at th
 http://your-server-ip:80
 ```
 
-Replace `your-server-ip` with the actual IP address or hostname configured in the `REACT_APP_CMF_API_URL` environment variable.
+Replace `your-server-ip` with the actual IP address or hostname configured in the `REACT_APP_CMF_API_URL` environment variable. The UI is also reachable over HTTPS at `https://your-server-ip:443`.
 
-> 📝 **Note:** Ensure that port 80 (or your configured `NGINX_HTTP_PORT`) is accessible and not blocked by firewall rules.
+> 📝 **Note:** Ensure that port 80 (or your configured `NGINX_HTTP_PORT`) and port 443 (or your configured `NGINX_HTTPS_PORT`) are accessible and not blocked by firewall rules.
 
-**Step 5: Stop the Containers**
+**Step 6: Stop the Containers**
 
 ```bash
 docker compose -f docker-compose-server.yml stop
 ```
-
-#### Enabling HTTPS
-
-The nginx service also listens on `NGINX_HTTPS_PORT` (container port 443) when
-a TLS certificate is present. To generate a self-signed certificate:
-
-```bash
-scripts/generate-self-signed-cert.sh
-```
-
-This writes `cmf.crt` and `cmf.key` into `$CMF_DATA_DIR/nginx-certs/`, which
-the `nginx` service mounts read-only at `/etc/nginx/certs/`. After generating
-the certificate, (re)start the stack and access CMF over HTTPS:
-
-```
-https://your-server-ip:443
-```
-
-> 📝 **Note:** Browsers will warn about the self-signed certificate. To use
-> your own certificate, copy your `cmf.crt` and `cmf.key` into
-> `$CMF_DATA_DIR/nginx-certs/` instead of running the script.
 
 #### Important Notes
 

--- a/env-example
+++ b/env-example
@@ -2,15 +2,16 @@
 NGINX_HTTP_PORT=80
 NGINX_HTTPS_PORT=443
 
-# HTTPS (required — nginx will not start without a certificate)
+# HTTPS (self-signed by default)
 # =========================================================================
-# The nginx service listens on NGINX_HTTPS_PORT (container port 443) and
-# REQUIRES a certificate at $CMF_DATA_DIR/nginx-certs/cmf.crt and a private
-# key at $CMF_DATA_DIR/nginx-certs/cmf.key. If these files are missing,
-# the nginx container will crash on startup.
+# The nginx service listens on NGINX_HTTPS_PORT (container port 443). An
+# entrypoint script auto-generates a throwaway self-signed certificate on
+# startup if none is found, so HTTPS works out of the box.
 #
-# Generate a self-signed certificate with:
+# For a STABLE certificate (persisted across restarts), generate one with:
 #   scripts/generate-self-signed-cert.sh
+# This writes cmf.crt and cmf.key into $CMF_DATA_DIR/nginx-certs/, which
+# the nginx service mounts at /etc/nginx/certs/.
 #
 # Or, to use your own certificate, copy cmf.crt and cmf.key into
 # $CMF_DATA_DIR/nginx-certs/ before starting the stack.

--- a/env-example
+++ b/env-example
@@ -2,11 +2,12 @@
 NGINX_HTTP_PORT=80
 NGINX_HTTPS_PORT=443
 
-# HTTPS (optional, self-signed by default)
+# HTTPS (required — nginx will not start without a certificate)
 # =========================================================================
 # The nginx service listens on NGINX_HTTPS_PORT (container port 443) and
-# expects a certificate at $CMF_DATA_DIR/nginx-certs/cmf.crt and a private
-# key at $CMF_DATA_DIR/nginx-certs/cmf.key.
+# REQUIRES a certificate at $CMF_DATA_DIR/nginx-certs/cmf.crt and a private
+# key at $CMF_DATA_DIR/nginx-certs/cmf.key. If these files are missing,
+# the nginx container will crash on startup.
 #
 # Generate a self-signed certificate with:
 #   scripts/generate-self-signed-cert.sh

--- a/env-example
+++ b/env-example
@@ -2,6 +2,18 @@
 NGINX_HTTP_PORT=80
 NGINX_HTTPS_PORT=443
 
+# HTTPS (optional, self-signed by default)
+# =========================================================================
+# The nginx service listens on NGINX_HTTPS_PORT (container port 443) and
+# expects a certificate at $CMF_DATA_DIR/nginx-certs/cmf.crt and a private
+# key at $CMF_DATA_DIR/nginx-certs/cmf.key.
+#
+# Generate a self-signed certificate with:
+#   scripts/generate-self-signed-cert.sh
+#
+# Or, to use your own certificate, copy cmf.crt and cmf.key into
+# $CMF_DATA_DIR/nginx-certs/ before starting the stack.
+
 # React App Configuration
 # REACT_APP_CMF_API_URL=URL:NGINX_PORT
 # If you change the NGINX port, make sure to update the same port number in the env variable REACT_APP_CMF_API_URL.

--- a/env-example
+++ b/env-example
@@ -17,9 +17,20 @@ NGINX_HTTPS_PORT=443
 # $CMF_DATA_DIR/nginx-certs/ before starting the stack.
 
 # React App Configuration
-# REACT_APP_CMF_API_URL=URL:NGINX_PORT
-# If you change the NGINX port, make sure to update the same port number in the env variable REACT_APP_CMF_API_URL.
-# This ensures that the frontend correctly communicates with the backend through the updated NGINX port.
+# =========================================================================
+# REACT_APP_CMF_API_URL is the URL the browser uses to fetch API calls from
+# the UI. Its scheme (http/https) and port MUST match how you access the UI
+# in the browser, otherwise the browser blocks API calls as mixed content.
+#
+# Choose ONE based on how you want to access the CMF web UI:
+#
+#   Access UI over HTTP (default, no cert warnings):
+#     REACT_APP_CMF_API_URL=http://<your-server-ip>:<NGINX_HTTP_PORT>
+#
+#   Access UI over HTTPS (self-signed cert; browser will warn):
+#     REACT_APP_CMF_API_URL=https://<your-server-ip>:<NGINX_HTTPS_PORT>
+#
+# If you change the NGINX port, update the same port number here.
 REACT_APP_CMF_API_URL=http://localhost:80
 
 # POSTGRES Configuration only for external postgress

--- a/nginx.conf
+++ b/nginx.conf
@@ -100,4 +100,85 @@ http {
             proxy_set_header Connection "upgrade";
         }
     }
+
+    # HTTPS server (self-signed cert by default; see scripts/generate-self-signed-cert.sh)
+    server {
+        listen 443 ssl;
+        server_name localhost;
+        client_max_body_size 0;  # 0 = no limit on request body size (needed for large mlmd file uploads)
+
+        ssl_certificate     /etc/nginx/certs/cmf.crt;
+        ssl_certificate_key /etc/nginx/certs/cmf.key;
+        ssl_protocols TLSv1.2 TLSv1.3;
+        ssl_ciphers HIGH:!aNULL:!MD5;
+
+        # Serve the static health check page
+        location = /check.html {
+            root /usr/share/nginx/html;
+            try_files /health.html =404;
+        }
+
+        # Route all API requests to the server
+        location /api/ {
+            proxy_pass http://server:8080/;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+            proxy_http_version 1.1;
+            proxy_set_header Upgrade $http_upgrade;
+            proxy_set_header Connection "upgrade";
+        }
+
+        # Proxy TensorBoard content at an internal path (UI wraps it at /tensorboard)
+        location /tensor_board/ {
+            proxy_pass http://tensorboard:6006;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+            proxy_http_version 1.1;
+            proxy_set_header Upgrade $http_upgrade;
+            proxy_set_header Connection "upgrade";
+        }
+
+        # Route MCP Server requests (StreamableHTTP transport)
+        location = /mcp {
+            proxy_pass http://mcp:8000/mcp;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+            proxy_set_header X-Forwarded-Host $host;
+            proxy_http_version 1.1;
+            proxy_buffering off;
+            proxy_cache off;
+            proxy_read_timeout 300s;
+        }
+
+        location /mcp/ {
+            proxy_pass http://mcp:8000/mcp/;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+            proxy_set_header X-Forwarded-Host $host;
+            proxy_http_version 1.1;
+            proxy_buffering off;
+            proxy_cache off;
+            proxy_read_timeout 300s;
+        }
+
+        # Route everything else to the UI
+        location / {
+            proxy_pass http://ui:3000/;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+            proxy_http_version 1.1;
+            proxy_set_header Upgrade $http_upgrade;
+            proxy_set_header Connection "upgrade";
+        }
+    }
 }

--- a/nginx.conf
+++ b/nginx.conf
@@ -107,8 +107,8 @@ http {
         server_name localhost;
         client_max_body_size 0;  # 0 = no limit on request body size (needed for large mlmd file uploads)
 
-        ssl_certificate     /etc/nginx/certs/cmf.crt;
-        ssl_certificate_key /etc/nginx/certs/cmf.key;
+        ssl_certificate     /etc/nginx/certs-active/cmf.crt;
+        ssl_certificate_key /etc/nginx/certs-active/cmf.key;
         ssl_protocols TLSv1.2 TLSv1.3;
         ssl_ciphers HIGH:!aNULL:!MD5;
 

--- a/scripts/generate-self-signed-cert.sh
+++ b/scripts/generate-self-signed-cert.sh
@@ -1,8 +1,10 @@
 #!/usr/bin/env bash
 # Generate a self-signed TLS certificate for the CMF nginx HTTPS endpoint.
 #
-# REQUIRED: the nginx service has a 443 ssl server block that will fail to
-# start without cmf.crt and cmf.key. Run this script before `docker compose up`.
+# Recommended but not strictly required: the nginx container's entrypoint
+# (scripts/nginx-autogen-cert.sh) will generate a throwaway cert on startup
+# if none is mounted. Run THIS script to create a STABLE cert that persists
+# across restarts and covers your hostname/IP in the SAN.
 #
 # Certs are written to $CMF_DATA_DIR/nginx-certs/ (or ./data/nginx-certs/ if
 # CMF_DATA_DIR is unset) and are consumed by the nginx service via the volume

--- a/scripts/generate-self-signed-cert.sh
+++ b/scripts/generate-self-signed-cert.sh
@@ -14,22 +14,56 @@
 # Defaults:
 #   OUTPUT_DIR = ${CMF_DATA_DIR:-./data}/nginx-certs
 #   HOSTNAME   = $(hostname)
-#   IP         = first IPv4 address reported by `hostname -I`
+#   IP         = first IPv4 address detected on this host (best-effort; see below)
 set -euo pipefail
 
 OUT_DIR="${1:-${CMF_DATA_DIR:-./data}/nginx-certs}"
 HOST="${2:-$(hostname)}"
-IP="${3:-$(hostname -I | awk '{print $1}')}"
+
+# Detect the host's primary IPv4 address. `hostname -I` is Linux-specific and
+# may be empty on macOS/minimal containers; fall back to `ip` and `ifconfig`.
+# If detection fails, the IP is simply omitted from the SAN — the cert still
+# validates for localhost and the hostname.
+detect_ip() {
+  local ip=""
+  # Linux: `hostname -I` prints space-separated IPv4/IPv6 list
+  ip="$(hostname -I 2>/dev/null | awk '{print $1}')" || ip=""
+  # Fallback: `ip -4 route get 1.1.1.1` (Linux)
+  if [ -z "$ip" ]; then
+    ip="$(ip -4 route get 1.1.1.1 2>/dev/null | awk '{for(i=1;i<=NF;i++) if($i=="src") {print $(i+1); exit}}')" || ip=""
+  fi
+  # Fallback: `ifconfig` (macOS / older Linux)
+  if [ -z "$ip" ]; then
+    ip="$(ifconfig 2>/dev/null | awk '/inet / && !/127.0.0.1/ {sub(/addr:/,"",$2); print $2; exit}')" || ip=""
+  fi
+  # Validate it looks like an IPv4 address
+  if [ -n "$ip" ] && printf '%s' "$ip" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$'; then
+    printf '%s' "$ip"
+  fi
+}
+IP="${3:-$(detect_ip)}"
 
 mkdir -p "$OUT_DIR"
+
+# Build the SAN extension. Always include localhost and the hostname as DNS
+# entries and 127.0.0.1 as an IP. Add the detected host IP only if non-empty
+# so we never produce a malformed `IP:` entry.
+SAN="DNS:localhost,DNS:$HOST,IP:127.0.0.1"
+if [ -n "$IP" ] && [ "$IP" != "127.0.0.1" ]; then
+  SAN="$SAN,IP:$IP"
+fi
 
 openssl req -x509 -nodes -newkey rsa:2048 -days 3650 \
   -keyout "$OUT_DIR/cmf.key" \
   -out     "$OUT_DIR/cmf.crt" \
   -subj "/CN=$HOST" \
-  -addext "subjectAltName=DNS:localhost,DNS:$HOST,IP:$IP,IP:127.0.0.1"
+  -addext "subjectAltName=$SAN"
 
 echo "Wrote $OUT_DIR/cmf.crt and $OUT_DIR/cmf.key"
 echo "  CN        : $HOST"
-echo "  SAN hosts : localhost, $HOST"
-echo "  SAN IPs   : $IP, 127.0.0.1"
+echo "  SAN       : $SAN"
+if [ -n "$IP" ]; then
+  echo "  Host IP   : $IP"
+else
+  echo "  Host IP   : (not detected — cert covers localhost and $HOST only)"
+fi

--- a/scripts/generate-self-signed-cert.sh
+++ b/scripts/generate-self-signed-cert.sh
@@ -1,6 +1,9 @@
 #!/usr/bin/env bash
 # Generate a self-signed TLS certificate for the CMF nginx HTTPS endpoint.
 #
+# REQUIRED: the nginx service has a 443 ssl server block that will fail to
+# start without cmf.crt and cmf.key. Run this script before `docker compose up`.
+#
 # Certs are written to $CMF_DATA_DIR/nginx-certs/ (or ./data/nginx-certs/ if
 # CMF_DATA_DIR is unset) and are consumed by the nginx service via the volume
 # mount defined in docker-compose-server.yml.

--- a/scripts/generate-self-signed-cert.sh
+++ b/scripts/generate-self-signed-cert.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# Generate a self-signed TLS certificate for the CMF nginx HTTPS endpoint.
+#
+# Certs are written to $CMF_DATA_DIR/nginx-certs/ (or ./data/nginx-certs/ if
+# CMF_DATA_DIR is unset) and are consumed by the nginx service via the volume
+# mount defined in docker-compose-server.yml.
+#
+# Usage:
+#   scripts/generate-self-signed-cert.sh [OUTPUT_DIR] [HOSTNAME] [IP]
+#
+# Defaults:
+#   OUTPUT_DIR = ${CMF_DATA_DIR:-./data}/nginx-certs
+#   HOSTNAME   = $(hostname)
+#   IP         = first IPv4 address reported by `hostname -I`
+set -euo pipefail
+
+OUT_DIR="${1:-${CMF_DATA_DIR:-./data}/nginx-certs}"
+HOST="${2:-$(hostname)}"
+IP="${3:-$(hostname -I | awk '{print $1}')}"
+
+mkdir -p "$OUT_DIR"
+
+openssl req -x509 -nodes -newkey rsa:2048 -days 3650 \
+  -keyout "$OUT_DIR/cmf.key" \
+  -out     "$OUT_DIR/cmf.crt" \
+  -subj "/CN=$HOST" \
+  -addext "subjectAltName=DNS:localhost,DNS:$HOST,IP:$IP,IP:127.0.0.1"
+
+echo "Wrote $OUT_DIR/cmf.crt and $OUT_DIR/cmf.key"
+echo "  CN        : $HOST"
+echo "  SAN hosts : localhost, $HOST"
+echo "  SAN IPs   : $IP, 127.0.0.1"

--- a/scripts/nginx-autogen-cert.sh
+++ b/scripts/nginx-autogen-cert.sh
@@ -1,0 +1,41 @@
+#!/bin/sh
+# Runs inside the nginx container before nginx starts (via /docker-entrypoint.d/).
+# Ensures /etc/nginx/certs-active/ contains cmf.crt and cmf.key so the 443 ssl
+# server block always has a certificate to load:
+#   - if the user mounted a certificate in /etc/nginx/certs/, use it
+#   - otherwise generate a throwaway self-signed cert (non-persistent)
+#
+# This prevents nginx from crashing on startup when the operator has not yet
+# run scripts/generate-self-signed-cert.sh on the host. For a stable/persistent
+# certificate, run that script (or supply your own cmf.crt/cmf.key in
+# $CMF_DATA_DIR/nginx-certs/).
+set -eu
+
+SRC_DIR=/etc/nginx/certs
+ACTIVE_DIR=/etc/nginx/certs-active
+mkdir -p "$ACTIVE_DIR"
+
+# Reuse a user-provided certificate if present and non-empty.
+if [ -s "$SRC_DIR/cmf.crt" ] && [ -s "$SRC_DIR/cmf.key" ]; then
+    cp "$SRC_DIR/cmf.crt" "$ACTIVE_DIR/cmf.crt"
+    cp "$SRC_DIR/cmf.key" "$ACTIVE_DIR/cmf.key"
+    echo "[autogen-cert] Using user-provided certificate from $SRC_DIR"
+    exit 0
+fi
+
+echo "[autogen-cert] No certificate found in $SRC_DIR; generating a throwaway self-signed cert"
+
+# nginx:alpine does not ship openssl; install it on demand.
+if ! command -v openssl >/dev/null 2>&1; then
+    echo "[autogen-cert] Installing openssl..."
+    apk add --no-cache openssl >/dev/null
+fi
+
+HOST="$(hostname 2>/dev/null || echo localhost)"
+openssl req -x509 -nodes -newkey rsa:2048 -days 3650 \
+    -keyout "$ACTIVE_DIR/cmf.key" \
+    -out     "$ACTIVE_DIR/cmf.crt" \
+    -subj "/CN=$HOST" \
+    -addext "subjectAltName=DNS:localhost,DNS:$HOST,IP:127.0.0.1" >/dev/null 2>&1
+
+echo "[autogen-cert] Generated throwaway self-signed cert for CN=$HOST (regenerated on each start)"

--- a/skills/README.md
+++ b/skills/README.md
@@ -185,7 +185,7 @@ Also covers the CLI equivalents (`cmf pipeline list`, `cmf execution list`, `cmf
 
 Two scenarios:
 
-1. **Local deployment** — clones the CMF repo, creates a `.env` file, generates a self-signed TLS certificate (`scripts/generate-self-signed-cert.sh`, **required** — nginx crashes without it), and starts the full server stack with `docker compose -f docker-compose-server.yml up -d`. Stack includes PostgreSQL, CMF API server, React UI, TensorBoard, MCP server, and Nginx (HTTP + HTTPS).
+1. **Local deployment** — clones the CMF repo, creates a `.env` file, optionally generates a stable self-signed TLS certificate (`scripts/generate-self-signed-cert.sh`; nginx also auto-generates a throwaway cert on startup if none is mounted), and starts the full server stack with `docker compose -f docker-compose-server.yml up -d`. Stack includes PostgreSQL, CMF API server, React UI, TensorBoard, MCP server, and Nginx (HTTP + HTTPS).
 
 2. **Connect to existing server** — if a CMF Server is already running (e.g. shared team server), configures the local `cmf init` to point at it with `--cmf-server-url`.
 

--- a/skills/README.md
+++ b/skills/README.md
@@ -185,11 +185,11 @@ Also covers the CLI equivalents (`cmf pipeline list`, `cmf execution list`, `cmf
 
 Two scenarios:
 
-1. **Local deployment** — clones the CMF repo, creates a `.env` file, and starts the full server stack with `docker compose -f docker-compose-server.yml up -d`. Stack includes PostgreSQL, CMF API server, React UI, TensorBoard, MCP server, and Nginx.
+1. **Local deployment** — clones the CMF repo, creates a `.env` file, generates a self-signed TLS certificate (`scripts/generate-self-signed-cert.sh`, **required** — nginx crashes without it), and starts the full server stack with `docker compose -f docker-compose-server.yml up -d`. Stack includes PostgreSQL, CMF API server, React UI, TensorBoard, MCP server, and Nginx (HTTP + HTTPS).
 
 2. **Connect to existing server** — if a CMF Server is already running (e.g. shared team server), configures the local `cmf init` to point at it with `--cmf-server-url`.
 
-Key `.env` variables covered: `CMF_DATA_DIR`, `NGINX_HTTP_PORT`, `REACT_APP_CMF_API_URL`, `POSTGRES_*`, `MCP_EXTERNAL_PORT`.
+Key `.env` variables covered: `CMF_DATA_DIR`, `NGINX_HTTP_PORT`, `NGINX_HTTPS_PORT`, `REACT_APP_CMF_API_URL`, `POSTGRES_*`, `MCP_EXTERNAL_PORT`.
 
 ---
 

--- a/skills/cmf-mcp/SKILL.md
+++ b/skills/cmf-mcp/SKILL.md
@@ -100,7 +100,7 @@ See [references/mcp-tools.md](references/mcp-tools.md) for the full tool referen
 ## Troubleshooting
 
 - **`Connection refused` on port 8000** — run `docker compose up -d` in `mcp/`
-- **CMF Server unreachable** — verify with `curl http://<cmf-server>:80/apiv1.0/pipelines`
+- **CMF Server unreachable** — verify with `curl http://<cmf-server>:80/api/pipelines`
 - **Tools not appearing** — restart the agent after updating `.mcp.json`
 - **Empty results** — push metadata first: `cmf metadata push -p <name>`
 

--- a/skills/cmf-server/SKILL.md
+++ b/skills/cmf-server/SKILL.md
@@ -44,9 +44,12 @@ MCP_EXTERNAL_PORT=8382
 
 See [references/env-variables.md](references/env-variables.md) for full variable descriptions and common customizations.
 
-### Step 3 — Generate the TLS certificate (required)
+### Step 3 — Generate the TLS certificate (recommended)
 
-The `nginx` service has a `443 ssl` server block and **will crash on startup if the certificate files are missing**. Generate a self-signed cert before starting the stack:
+The `nginx` service has a `443 ssl` server block. An entrypoint script
+auto-generates a **throwaway** self-signed cert on startup if none is mounted,
+so HTTPS works out of the box. For a **stable** cert that persists across
+restarts and covers your hostname/IP, run the helper before starting the stack:
 
 ```bash
 scripts/generate-self-signed-cert.sh
@@ -122,7 +125,7 @@ docker compose -f docker-compose-server.yml up -d
 ## Troubleshooting
 
 - **`REACT_APP_CMF_API_URL` not set** — required; set to the host's IP/hostname
-- **`nginx` crashes on startup** — almost always a missing TLS certificate. Run `scripts/generate-self-signed-cert.sh` (or place your own `cmf.crt` / `cmf.key` in `$CMF_DATA_DIR/nginx-certs/`), then `docker compose -f docker-compose-server.yml up -d`. Check with `docker compose -f docker-compose-server.yml logs nginx`.
+- **`nginx` crashes on startup** — an entrypoint script should auto-generate a throwaway cert if none is mounted; if nginx still crashes, check `docker compose -f docker-compose-server.yml logs nginx`. For a stable cert, run `scripts/generate-self-signed-cert.sh` (or place your own `cmf.crt` / `cmf.key` in `$CMF_DATA_DIR/nginx-certs/`).
 - **Port 80 in use** — change `NGINX_HTTP_PORT` and update `REACT_APP_CMF_API_URL` to match
 - **`postgres` not healthy** — check `docker compose -f docker-compose-server.yml logs postgres`; usually a `CMF_DATA_DIR` permissions issue
 - **UI loads but API calls fail** — use the host IP, not `localhost`, in `REACT_APP_CMF_API_URL`; must be reachable from the browser

--- a/skills/cmf-server/SKILL.md
+++ b/skills/cmf-server/SKILL.md
@@ -31,6 +31,12 @@ cd cmf
 CMF_DATA_DIR=./data
 NGINX_HTTP_PORT=80
 NGINX_HTTPS_PORT=443
+
+# Choose the scheme that matches how you'll access the UI in the browser:
+#   HTTP  -> http://<your-server-ip>:80
+#   HTTPS -> https://<your-server-ip>:443
+# The scheme MUST match the URL you open in the browser, or the browser will
+# block API calls as mixed content.
 REACT_APP_CMF_API_URL=http://<your-server-ip>:80
 
 POSTGRES_USER=myuser
@@ -73,7 +79,11 @@ curl http://<your-server-ip>:80/api/pipelines
 # []
 ```
 
-Open `http://<your-server-ip>:80` (or `https://<your-server-ip>:443`, accepting the self-signed cert warning) in a browser — CMF web UI should load.
+Open the CMF web UI in a browser using the URL that matches your `REACT_APP_CMF_API_URL` scheme:
+- **HTTP**: `http://<your-server-ip>:<NGINX_HTTP_PORT>` (no cert warnings)
+- **HTTPS**: `https://<your-server-ip>:<NGINX_HTTPS_PORT>` (accept the self-signed cert warning)
+
+The scheme used to open the UI **must match** the scheme in `REACT_APP_CMF_API_URL`, or the browser will block API calls as mixed content.
 
 ### Step 6 — Point clients at the server
 
@@ -128,7 +138,7 @@ docker compose -f docker-compose-server.yml up -d
 - **`nginx` crashes on startup** — an entrypoint script should auto-generate a throwaway cert if none is mounted; if nginx still crashes, check `docker compose -f docker-compose-server.yml logs nginx`. For a stable cert, run `scripts/generate-self-signed-cert.sh` (or place your own `cmf.crt` / `cmf.key` in `$CMF_DATA_DIR/nginx-certs/`).
 - **Port 80 in use** — change `NGINX_HTTP_PORT` and update `REACT_APP_CMF_API_URL` to match
 - **`postgres` not healthy** — check `docker compose -f docker-compose-server.yml logs postgres`; usually a `CMF_DATA_DIR` permissions issue
-- **UI loads but API calls fail** — use the host IP, not `localhost`, in `REACT_APP_CMF_API_URL`; must be reachable from the browser
+- **UI loads but API calls fail** — use the host IP, not `localhost`, in `REACT_APP_CMF_API_URL`; must be reachable from the browser. Also ensure the scheme matches how you open the UI: loading `https://...` with an `http://` API URL causes mixed-content blocking and shows "Server connection refused"
 - **MCP server not reachable** — check `MCP_EXTERNAL_PORT` in `.env` and confirm it is not blocked by a firewall; test with `curl http://<server-ip>:<MCP_EXTERNAL_PORT>/health`
 - **Clients cannot push metadata** — confirm `cmf init show` shows the correct server URL; verify with `curl http://<server-ip>:80/api/pipelines` (expect `[]` for an empty server, or a list of pipeline names)
 

--- a/skills/cmf-server/SKILL.md
+++ b/skills/cmf-server/SKILL.md
@@ -15,7 +15,8 @@ First check: **is a CMF Server already running?** If yes, skip to [Connecting to
 ### Prerequisites
 - Docker Engine + Docker Compose plugin
 - Host IP or hostname (for `REACT_APP_CMF_API_URL`)
-- Ports 80 and 443 free (configurable)
+- Ports 80 and 443 free (configurable via `NGINX_HTTP_PORT` / `NGINX_HTTPS_PORT`)
+- `openssl` on the host (for the self-signed cert helper)
 
 ### Step 1 — Clone CMF
 
@@ -43,25 +44,35 @@ MCP_EXTERNAL_PORT=8382
 
 See [references/env-variables.md](references/env-variables.md) for full variable descriptions and common customizations.
 
-### Step 3 — Start
+### Step 3 — Generate the TLS certificate (required)
+
+The `nginx` service has a `443 ssl` server block and **will crash on startup if the certificate files are missing**. Generate a self-signed cert before starting the stack:
+
+```bash
+scripts/generate-self-signed-cert.sh
+```
+
+This writes `cmf.crt` and `cmf.key` into `$CMF_DATA_DIR/nginx-certs/`, which the `nginx` service mounts read-only at `/etc/nginx/certs/`. To use your own certificate instead, copy your `cmf.crt` / `cmf.key` into that directory.
+
+### Step 4 — Start
 
 ```bash
 docker compose -f docker-compose-server.yml up -d
 docker compose -f docker-compose-server.yml ps   # all services should be healthy within ~60s
 ```
 
-Services started: `postgres`, `server` (CMF API), `ui` (React), `tensorboard`, `nginx`, `mcp`.
+Services started: `postgres`, `server` (CMF API), `ui` (React), `tensorboard`, `nginx` (HTTP + HTTPS), `mcp`.
 
-### Step 4 — Verify
+### Step 5 — Verify
 
 ```bash
-curl http://<your-server-ip>:80/apiv1.0/pipelines
-# {"pipelines": []}
+curl http://<your-server-ip>:80/api/pipelines
+# []
 ```
 
-Open `http://<your-server-ip>:80` in a browser — CMF web UI should load.
+Open `http://<your-server-ip>:80` (or `https://<your-server-ip>:443`, accepting the self-signed cert warning) in a browser — CMF web UI should load.
 
-### Step 5 — Point clients at the server
+### Step 6 — Point clients at the server
 
 On each client machine:
 ```bash
@@ -111,11 +122,12 @@ docker compose -f docker-compose-server.yml up -d
 ## Troubleshooting
 
 - **`REACT_APP_CMF_API_URL` not set** — required; set to the host's IP/hostname
+- **`nginx` crashes on startup** — almost always a missing TLS certificate. Run `scripts/generate-self-signed-cert.sh` (or place your own `cmf.crt` / `cmf.key` in `$CMF_DATA_DIR/nginx-certs/`), then `docker compose -f docker-compose-server.yml up -d`. Check with `docker compose -f docker-compose-server.yml logs nginx`.
 - **Port 80 in use** — change `NGINX_HTTP_PORT` and update `REACT_APP_CMF_API_URL` to match
 - **`postgres` not healthy** — check `docker compose -f docker-compose-server.yml logs postgres`; usually a `CMF_DATA_DIR` permissions issue
 - **UI loads but API calls fail** — use the host IP, not `localhost`, in `REACT_APP_CMF_API_URL`; must be reachable from the browser
 - **MCP server not reachable** — check `MCP_EXTERNAL_PORT` in `.env` and confirm it is not blocked by a firewall; test with `curl http://<server-ip>:<MCP_EXTERNAL_PORT>/health`
-- **Clients cannot push metadata** — confirm `cmf init show` shows the correct server URL; verify with `curl http://<server-ip>:80/apiv1.0/pipelines`
+- **Clients cannot push metadata** — confirm `cmf init show` shows the correct server URL; verify with `curl http://<server-ip>:80/api/pipelines` (expect `[]` for an empty server, or a list of pipeline names)
 
 ---
 

--- a/skills/cmf-server/references/env-variables.md
+++ b/skills/cmf-server/references/env-variables.md
@@ -19,7 +19,7 @@ All variables are set in the `.env` file in the same directory as `docker-compos
 | Variable | Default | Purpose |
 |----------|---------|---------|
 | `NGINX_HTTP_PORT` | `80` | Host port for HTTP |
-| `NGINX_HTTPS_PORT` | `443` | Host port for HTTPS. **Requires a TLS certificate** at `$CMF_DATA_DIR/nginx-certs/cmf.crt` and key at `cmf.key`; nginx will crash on startup without them. Generate with `scripts/generate-self-signed-cert.sh`. |
+| `NGINX_HTTPS_PORT` | `443` | Host port for HTTPS. nginx auto-generates a throwaway self-signed cert on startup if none is mounted; for a stable cert, run `scripts/generate-self-signed-cert.sh` (or place `cmf.crt` / `cmf.key` in `$CMF_DATA_DIR/nginx-certs/`). |
 | `MCP_EXTERNAL_PORT` | `8382` | Host port mapped to the CMF MCP server |
 
 ## PostgreSQL

--- a/skills/cmf-server/references/env-variables.md
+++ b/skills/cmf-server/references/env-variables.md
@@ -6,7 +6,7 @@ All variables are set in the `.env` file in the same directory as `docker-compos
 
 | Variable | Example | Purpose |
 |----------|---------|---------|
-| `REACT_APP_CMF_API_URL` | `http://192.168.1.10:80` | URL clients and the browser use to reach the CMF API. Must be reachable from client machines — use the host IP, not `localhost` if accessed remotely. |
+| `REACT_APP_CMF_API_URL` | `http://192.168.1.10:80` | URL the **browser** uses to fetch API calls from the UI. Must be reachable from client machines — use the host IP, not `localhost` if accessed remotely. **The scheme (`http`/`https`) must match how you open the UI**, or the browser blocks API calls as mixed content. |
 
 ## Storage
 
@@ -43,11 +43,20 @@ All variables are set in the `.env` file in the same directory as `docker-compos
 
 ## Common customizations
 
-**Non-standard HTTP port:**
+**Non-standard HTTP port (UI over HTTP):**
 ```env
 NGINX_HTTP_PORT=8080
 REACT_APP_CMF_API_URL=http://192.168.1.10:8080
 ```
+
+**UI over HTTPS (self-signed cert):**
+```env
+NGINX_HTTPS_PORT=8443
+REACT_APP_CMF_API_URL=https://192.168.1.10:8443
+```
+> The scheme in `REACT_APP_CMF_API_URL` must match the URL you open in the
+> browser. Loading the UI over `https://` with an `http://` API URL causes
+> mixed-content blocking.
 
 **External data volume:**
 ```env

--- a/skills/cmf-server/references/env-variables.md
+++ b/skills/cmf-server/references/env-variables.md
@@ -19,7 +19,7 @@ All variables are set in the `.env` file in the same directory as `docker-compos
 | Variable | Default | Purpose |
 |----------|---------|---------|
 | `NGINX_HTTP_PORT` | `80` | Host port for HTTP |
-| `NGINX_HTTPS_PORT` | `443` | Host port for HTTPS |
+| `NGINX_HTTPS_PORT` | `443` | Host port for HTTPS. **Requires a TLS certificate** at `$CMF_DATA_DIR/nginx-certs/cmf.crt` and key at `cmf.key`; nginx will crash on startup without them. Generate with `scripts/generate-self-signed-cert.sh`. |
 | `MCP_EXTERNAL_PORT` | `8382` | Host port mapped to the CMF MCP server |
 
 ## PostgreSQL
@@ -52,6 +52,12 @@ REACT_APP_CMF_API_URL=http://192.168.1.10:8080
 **External data volume:**
 ```env
 CMF_DATA_DIR=/mnt/nfs/cmf-data
+```
+
+**Bring-your-own TLS certificate** (instead of the self-signed one):
+```env
+# Place cmf.crt and cmf.key in $CMF_DATA_DIR/nginx-certs/ before starting.
+# No env change required — nginx reads them from the mounted certs dir.
 ```
 
 **Multi-environment MCP:**


### PR DESCRIPTION
Add a 443 ssl server block to nginx.conf mirroring the existing HTTP routes (api, tensor_board, mcp, ui), mount $CMF_DATA_DIR/nginx-certs into the nginx container, and ship a helper script (scripts/generate-self-signed-cert.sh) that produces a SAN-covered self-signed cert. Document the flow in env-example and docs/setup.

Users can drop in their own cmf.crt/cmf.key to override.

# Related Issues / Pull Requests

#370 

# Description

Include a brief summary of the proposed changes.

# What changes are proposed in this pull request?

- [X] Bug fix (non-breaking change which fixes an issue).
- [] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected; for instance, 
      examples in this repository need to be updated too).
- [ ] This change requires a documentation update.

# Checklist:

- [X] My code follows the style guidelines of this project (PEP-8 with Google-style docstrings).
- [X] My code modifies existing public API, or introduces new public API, and I updated or wrote docstrings that
      uses Google-style formatting and any other formatting that is supported by mkdocs and plugins this project
      uses.
- [X] I have commented my code.
- [X] My code requires documentation updates, and I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
