### PR TITLE
fix(init): add cmf_origin remote in existing git repos (#374)

### DIFF
--- a/cmflib/commands/init/amazonS3.py
+++ b/cmflib/commands/init/amazonS3.py
@@ -28,6 +28,7 @@ from cmflib.dvc_wrapper import (
     dvc_add_remote_repo,
     dvc_add_attribute,
     git_modify_remote_url,
+    git_add_or_modify_remote_url,
 )
 from cmflib.utils.cmf_config import CmfConfig
 from cmflib.utils.helper_functions import is_git_repo
@@ -89,7 +90,7 @@ class CmdInitAmazonS3(CmdBase):
             git_add_remote(self.args.git_remote_url[0])
             print("git init complete.")
         else:
-            git_modify_remote_url(self.args.git_remote_url[0])
+            git_add_or_modify_remote_url(self.args.git_remote_url[0])
             print("git init complete.")
 
 

--- a/cmflib/commands/init/local.py
+++ b/cmflib/commands/init/local.py
@@ -28,6 +28,7 @@ from cmflib.dvc_wrapper import (
     dvc_quiet_init,
     dvc_add_remote_repo,
     git_modify_remote_url,
+    git_add_or_modify_remote_url,
 )
 from cmflib.utils.cmf_config import CmfConfig
 from cmflib.utils.helper_functions import is_git_repo
@@ -88,7 +89,7 @@ class CmdInitLocal(CmdBase):
             git_add_remote(self.args.git_remote_url[0])
             print("git init complete.")
         else:
-            git_modify_remote_url(self.args.git_remote_url[0])
+            git_add_or_modify_remote_url(self.args.git_remote_url[0])
             print("git init complete.")
 
         print("Starting cmf init.")

--- a/cmflib/commands/init/minioS3.py
+++ b/cmflib/commands/init/minioS3.py
@@ -28,6 +28,7 @@ from cmflib.dvc_wrapper import (
     dvc_add_remote_repo,
     dvc_add_attribute,
     git_modify_remote_url,
+    git_add_or_modify_remote_url,
 )
 from cmflib.utils.cmf_config import CmfConfig
 from cmflib.utils.helper_functions import is_git_repo
@@ -90,7 +91,7 @@ class CmdInitMinioS3(CmdBase):
             git_add_remote(self.args.git_remote_url[0])
             print("git init complete.")
         else:
-            git_modify_remote_url(self.args.git_remote_url[0])
+            git_add_or_modify_remote_url(self.args.git_remote_url[0])
             print("git init complete.")
 
 

--- a/cmflib/commands/init/osdfremote.py
+++ b/cmflib/commands/init/osdfremote.py
@@ -29,6 +29,7 @@ from cmflib.dvc_wrapper import (
     dvc_quiet_init,
     dvc_add_remote_repo,
     dvc_add_attribute,
+    git_add_or_modify_remote_url,
 )
 from cmflib.utils.cmf_config import CmfConfig
 from cmflib.utils.helper_functions import is_git_repo
@@ -87,6 +88,9 @@ class CmdInitOSDFRemote(CmdBase):
             git_checkout_new_branch(branch_name)
             git_initial_commit()
             git_add_remote(self.args.git_remote_url)
+            print("git init complete.")
+        else:
+            git_add_or_modify_remote_url(self.args.git_remote_url)
             print("git init complete.")
 
         print("Starting cmf init.")

--- a/cmflib/commands/init/sshremote.py
+++ b/cmflib/commands/init/sshremote.py
@@ -29,6 +29,7 @@ from cmflib.dvc_wrapper import (
     dvc_quiet_init,
     dvc_add_remote_repo,
     dvc_add_attribute,
+    git_add_or_modify_remote_url,
 )
 from cmflib.utils.cmf_config import CmfConfig
 from cmflib.utils.helper_functions import is_git_repo
@@ -87,6 +88,9 @@ class CmdInitSSHRemote(CmdBase):
             git_checkout_new_branch(branch_name)
             git_initial_commit()
             git_add_remote(self.args.git_remote_url[0])
+            print("git init complete.")
+        else:
+            git_add_or_modify_remote_url(self.args.git_remote_url[0])
             print("git init complete.")
 
         print("Starting cmf init.")

--- a/cmflib/dvc_wrapper.py
+++ b/cmflib/dvc_wrapper.py
@@ -505,6 +505,29 @@ def git_modify_remote_url(git_url) -> str:
     return commit
 
 
+def git_add_or_modify_remote_url(git_url) -> str:
+    commit = ""
+    try:
+        process = subprocess.Popen(['git', 'remote', 'get-url', 'cmf_origin'],
+                                   stdout=subprocess.PIPE,
+                                   stderr=subprocess.PIPE,
+                                   universal_newlines=True)
+        output, errs = process.communicate(timeout=60)
+        if process.returncode == 0:
+            git_modify_remote_url(git_url)
+        else:
+            git_add_remote(git_url)
+
+    except Exception as err:
+        logger.error(f"[git_add_or_modify_remote_url] Unexpected {err}, {type(err)}")
+        if isinstance(object, subprocess.Popen):
+           process.kill()
+           outs, errs = process.communicate()
+           logger.error(f"[git_add_or_modify_remote_url] Unexpected {outs}")
+           logger.error(f"[git_add_or_modify_remote_url] Unexpected {errs}")
+    return commit
+
+
 # Pulling code from branch
 def git_get_pull(branch_name: str) -> t.Tuple[str, str, int]:
     process = subprocess.Popen(f'git pull cmf_origin {branch_name}', 


### PR DESCRIPTION


# Related Issues / Pull Requests

#374 

# Description

cmf init in an existing git repo failed to add the cmf_origin remote: local/minioS3/amazonS3 called git remote set-url on a non-existent remote (error swallowed by try/except -> false SUCCESS), and sshremote/osdfremote skipped the else branch entirely.

Add git_add_or_modify_remote_url() helper that checks whether cmf_origin exists (git remote get-url) and calls git_add_remote or git_modify_remote_url accordingly. Use it in the else branch of all five init backends.

# What changes are proposed in this pull request?

- [X] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected; for instance, 
      examples in this repository need to be updated too).
- [ ] This change requires a documentation update.

# Checklist:

- [X] My code follows the style guidelines of this project (PEP-8 with Google-style docstrings).
- [ ] My code modifies existing public API, or introduces new public API, and I updated or wrote docstrings that
      uses Google-style formatting and any other formatting that is supported by mkdocs and plugins this project
      uses.
- [ ] I have commented my code.
- [ ] My code requires documentation updates, and I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
